### PR TITLE
Define spatial AOI for example WQP data pull

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -1,3 +1,5 @@
+source('scratch/download_file.R')
+
 p1_targets_list <- list(
   
   # Get common parameter groups and WQP CharacteristicNames
@@ -16,6 +18,24 @@ p1_targets_list <- list(
   tar_target(
     p1_charNames,
     p1_wqp_params[param_groups_select]
+  ),
+  
+  # Define the spatial area of interest (AOI) for the WQP data pull
+  # This target could also be edited to read in coordinates from a local file
+  # that contains the columns 'lon' and 'lat', e.g. replace data.frame() with 
+  # read_csv("1_fetch/in/my_sites.csv")
+  tar_target(
+    p1_AOI,
+    data.frame(lon = coords_lon,
+               lat = coords_lat)
+  ),
+  
+  # Create a spatial (sf) object representing the area of interest
+  tar_target(
+    p1_AOI_sf,
+    sf::st_as_sf(p1_AOI,coords=c("lon","lat"),crs=4326) %>%
+      summarize(geometry = st_combine(geometry)) %>%
+      sf::st_cast("POLYGON")
   )
 
 )

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -1,4 +1,3 @@
-source('scratch/download_file.R')
 
 p1_targets_list <- list(
   
@@ -23,7 +22,8 @@ p1_targets_list <- list(
   # Define the spatial area of interest (AOI) for the WQP data pull
   # This target could also be edited to read in coordinates from a local file
   # that contains the columns 'lon' and 'lat', e.g. replace data.frame() with 
-  # read_csv("1_fetch/in/my_sites.csv")
+  # read_csv("1_fetch/in/my_sites.csv"). See README for an example of how to 
+  # use a shapefile to define the AOI.
   tar_target(
     p1_AOI,
     data.frame(lon = coords_lon,

--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # ds-pipelines-targets-example-wqp
 An example targets pipeline for pulling data from the Water Quality Portal (WQP)
+
+## Defining the spatial area of interest
+In this workflow we define our spatial area of interest from a set of coordinates that we define in the `_targets.R` file. These coordinates represent the vertices of a simple triangle polygon that represents the spatial extent of our WQP data pull. 
+
+We could also use existing watershed boundaries or another polygon from an external data source to define our area of interest. For example, we could replace the targets `p1_AOI` and `p1_AOI_sf` with targets that download and read in an external shapefile:
+
+```
+# Download a shapefile containing the Delaware River Basin boundaries
+# We changed the storage format for this target to format = "file" so that tar_make() will
+# track this target and automatically re-run any downstream targets if the zip file changes. 
+# A file target must return a character vector indicating the path of local files and/or
+# directories. To return a character vector with the local file path, we call download_function(),
+# which is a wrapper function for utils::download.file that returns the character vector that 
+# is used for the fileout argument.
+tar_target(
+  p1_shp_zip,
+  download_file("https://www.state.nj.us/drbc/library/documents/GIS/drbbnd.zip",
+                fileout = "1_fetch/out/drbbnd.zip", 
+                mode = "wb", quiet = TRUE),
+  format = "file"
+),
+
+# Unzip the shapefile and read in as an sf object
+tar_target(
+  p1_shp_sf,
+  {
+    unzip(zipfile = p1_shp_zip, exdir = "scratch/drbbnd", overwrite = TRUE)
+    sf::st_read("scratch/drbbnd/drb_bnd_arc.shp", quiet = TRUE)
+  }
+)
+  
+```
+

--- a/README.md
+++ b/README.md
@@ -11,24 +11,31 @@ We could also use existing watershed boundaries or another polygon from an exter
 # We changed the storage format for this target to format = "file" so that tar_make() will
 # track this target and automatically re-run any downstream targets if the zip file changes. 
 # A file target must return a character vector indicating the path of local files and/or
-# directories. To return a character vector with the local file path, we call download_function(),
-# which is a wrapper function for utils::download.file that returns the character vector that 
-# is used for the fileout argument.
-tar_target(
-  p1_shp_zip,
-  download_file("https://www.state.nj.us/drbc/library/documents/GIS/drbbnd.zip",
-                fileout = "1_fetch/out/drbbnd.zip", 
-                mode = "wb", quiet = TRUE),
-  format = "file"
-),
+# directories. Below, we include all of the code needed to build the target between {} and 
+# return the variable fileout to satisfy the format = "file" requirements. Running the 
+# command tar_load(p1_shp_zip) should display the string used to define fileout.
+  tar_target(
+    p1_shp_zip,
+    {
+      # mode is a character string indicating the mode used to write the file; see 
+      # ??utils::download.file for details.
+      fileout <- "1_fetch/out/drbbnd.zip"
+      utils::download.file("https://www.state.nj.us/drbc/library/documents/GIS/drbbnd.zip",
+                  destfile = fileout, 
+                  mode = "wb", quiet = TRUE)
+      fileout
+    },
+    format = "file"
+  ),
 
 # Unzip the shapefile and read in as an sf object
 tar_target(
-  p1_shp_sf,
-  {
-    unzip(zipfile = p1_shp_zip, exdir = "scratch/drbbnd", overwrite = TRUE)
-    sf::st_read("scratch/drbbnd/drb_bnd_arc.shp", quiet = TRUE)
-  }
+    p1_shp_sf,
+    {
+      savedir <- tools::file_path_sans_ext(p1_shp_zip)
+      unzip(zipfile = p1_shp_zip, exdir = savedir, overwrite = TRUE)
+      sf::st_read(paste0(savedir,"/drb_bnd_arc.shp"), quiet = TRUE)
+    }
 )
   
 ```

--- a/_targets.R
+++ b/_targets.R
@@ -1,7 +1,7 @@
 library(targets)
 
 options(tidyverse.quiet = TRUE)
-tar_option_set(packages = c('tidyverse', 'lubridate', 'dataRetrieval'))
+tar_option_set(packages = c('tidyverse', 'lubridate', 'dataRetrieval', 'sf'))
 
 source("1_fetch.R")
 
@@ -9,17 +9,14 @@ source("1_fetch.R")
 start_date <- '2015-01-01'
 end_date <- '2015-12-31'
 
-# The spatial extent of our data pull is the Delaware River Basin (DRB), so 
-# here we will define the minor HUCs (hydrologic unit codes) that make up the 
-# DRB to pass to data download functions in dataRetrieval. 
-# The DRB is represented by subregion '0204' (https://water.usgs.gov/GIS/huc_name.html)
-drb_huc8s <- c('02040101','02040102','02040103','02040104','02040105','02040106',
-               '02040201','02040202','02040203','02040204','02040205','02040206','02040207')
-
 # Define which parameter groups (and CharacteristicNames) to return from WQP 
 # options for parameter groups are represented in first level of 1_fetch/cfg/wqp_codes.yml
 param_groups_select <- c('nitrate','conductivity')
 
+# Specify coordinates that define the spatial area of interest
+# lat/lon are referenced to WGS84
+coords_lon <- c(-77.063, -75.333, -75.437)
+coords_lat <- c(40.547, 41.029, 39.880)
 
 # Return the complete list of targets
 c(p1_targets_list)


### PR DESCRIPTION
Addresses #11.

Here I've defined our area of interest as a simple triangle polygon that might represent a watershed or bounding box. The code changes represent the following steps:

- add vectors containing the input coordinates within `_targets.R`
- use the input coordinates to create a data frame in `p1_AOI`. This target isn't really necessary, but I've added it to document/show where a user could read in a list of coordinates instead
- create an sf object that represents our area of interest

We had previously considered using a watershed shapefile to define our spatial domain, and I expect many users might be interested in doing that. Here we've opted for a simpler scheme to hopefully make this repo more maintainable, so I added some text in the README that shows how you could replace the existing targets with targets that download and/or read in an external shapefile.

Here's a preview of our example AOI:

![AOI](https://user-images.githubusercontent.com/8785034/159079109-ac1a9fef-1771-4d6f-9812-bbb44d697c41.png)

