### PR TITLE
Create big grid to use for inventorying WQP data

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -56,7 +56,7 @@ p1_targets_list <- list(
   # (buffered here using a 5 km buffer distance). These boxes will be used
   # to query the WQP.
   tar_target(
-    p1_overlapping_boxes,
+    p1_conus_grid_aoi,
     {
       # Project area of interest to calculate buffer and set up for intersection
       buffered_AOI <- p1_AOI_sf %>%

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -51,19 +51,7 @@ p1_targets_list <- list(
   # to query the WQP.
   tar_target(
     p1_conus_grid_aoi,
-    {
-      # Project area of interest to calculate buffer and set up for intersection
-      buffered_AOI <- p1_AOI_sf %>%
-        sf::st_transform(5070) %>%
-        sf::st_buffer(5000)
-      
-      # Filter the big grid of boxes to only include those that overlap
-      # with the buffered area of interest
-      p1_conus_grid %>%
-        sf::st_transform(5070) %>%
-        sf::st_filter(y = buffered_AOI,
-                      .predicate = st_intersects)
-    }
+    subset_grids_to_aoi(p1_conus_grid, p1_AOI_sf, buffer_dist_m = 5000)
   )
 
 )

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -56,7 +56,7 @@ p1_targets_list <- list(
   # (buffered here using a 5 km buffer distance). These boxes will be used
   # to query the WQP.
   tar_target(
-    p1_boxes_for_query,
+    p1_overlapping_boxes,
     {
       # Project area of interest to calculate buffer and set up for intersection
       buffered_AOI <- p1_AOI_sf %>%
@@ -66,7 +66,7 @@ p1_targets_list <- list(
       # Filter the big grid of boxes to only include those that overlap
       # with the buffered area of interest
       p1_conus_grid %>%
-        st_transform(5070) %>%
+        sf::st_transform(5070) %>%
         sf::st_filter(y = buffered_AOI,
                       .predicate = st_intersects)
     }

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -1,3 +1,5 @@
+# Source the functions that will be used to build the targets in p1_targets_list
+source("1_fetch/src/create_conus_grid.R")
 
 p1_targets_list <- list(
   
@@ -41,15 +43,7 @@ p1_targets_list <- list(
   # Create a big grid of boxes to set up chunked data queries
   tar_target(
     p1_conus_grid,
-    tigris::states(class = "sf", year = 2020, progress_bar = FALSE) %>%
-      # filter state polygons to CONUS extent
-      filter(REGION != "9", 
-             !STUSPS %in% c("HI","AK")) %>%
-      # create square grid with cell sizes equal to 1 deg. x 1 deg.
-      sf::st_make_grid(cellsize = c(1,1), square = TRUE) %>%
-      # convert to sf object and add an "id" attribute
-      sf::st_as_sf() %>%
-      mutate(id = row.names(.))
+    create_conus_grid(cellsize = c(1,1))
   ),
   
   # Use spatial subsetting to find boxes that overlap the area of interest

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -50,6 +50,26 @@ p1_targets_list <- list(
       # convert to sf object and add an "id" attribute
       sf::st_as_sf() %>%
       mutate(id = row.names(.))
+  ),
+  
+  # Use spatial subsetting to find boxes that overlap the area of interest
+  # (buffered here using a 5 km buffer distance). These boxes will be used
+  # to query the WQP.
+  tar_target(
+    p1_boxes_for_query,
+    {
+      # Project area of interest to calculate buffer and set up for intersection
+      buffered_AOI <- p1_AOI_sf %>%
+        sf::st_transform(5070) %>%
+        sf::st_buffer(5000)
+      
+      # Filter the big grid of boxes to only include those that overlap
+      # with the buffered area of interest
+      p1_conus_grid %>%
+        st_transform(5070) %>%
+        sf::st_filter(y = buffered_AOI,
+                      .predicate = st_intersects)
+    }
   )
 
 )

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -1,5 +1,5 @@
 # Source the functions that will be used to build the targets in p1_targets_list
-source("1_fetch/src/create_conus_grid.R")
+source("1_fetch/src/create_grids.R")
 
 p1_targets_list <- list(
   

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -36,6 +36,20 @@ p1_targets_list <- list(
     sf::st_as_sf(p1_AOI,coords=c("lon","lat"),crs=4326) %>%
       summarize(geometry = st_combine(geometry)) %>%
       sf::st_cast("POLYGON")
+  ),
+  
+  # Create a big grid of boxes to set up chunked data queries
+  tar_target(
+    p1_conus_grid,
+    tigris::states(class = "sf", year = 2020, progress_bar = FALSE) %>%
+      # filter state polygons to CONUS extent
+      filter(REGION != "9", 
+             !STUSPS %in% c("HI","AK")) %>%
+      # create square grid with cell sizes equal to 1 deg. x 1 deg.
+      sf::st_make_grid(cellsize = c(1,1), square = TRUE) %>%
+      # convert to sf object and add an "id" attribute
+      sf::st_as_sf() %>%
+      mutate(id = row.names(.))
   )
 
 )

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -47,11 +47,11 @@ p1_targets_list <- list(
   ),
   
   # Use spatial subsetting to find boxes that overlap the area of interest
-  # (buffered here using a 5 km buffer distance). These boxes will be used
-  # to query the WQP.
+  # (i.e., are within dist_m of p1_AOI_sf). These boxes will be used to
+  # query the WQP.
   tar_target(
     p1_conus_grid_aoi,
-    subset_grids_to_aoi(p1_conus_grid, p1_AOI_sf, buffer_dist_m = 5000)
+    subset_grids_to_aoi(p1_conus_grid, p1_AOI_sf, dist_m = 5000)
   )
 
 )

--- a/1_fetch/src/create_grids.R
+++ b/1_fetch/src/create_grids.R
@@ -32,7 +32,7 @@ create_conus_grid <- function(cellsize, year = 2020, progress_bar = FALSE){
 
 
 
-subset_grids_to_aoi <- function(grid, aoi_poly, buffer_dist_m){
+subset_grids_to_aoi <- function(grid, aoi_poly, dist_m){
   #' 
   #' @description Function to spatially subset a holistic grid of boxes
   #' to find the boxes that overlap the area of interest. The area of 
@@ -41,26 +41,20 @@ subset_grids_to_aoi <- function(grid, aoi_poly, buffer_dist_m){
   #' @param grid sf polygon object containing the geometries and an attribute 
   #' id for each box within the grid.
   #' @param aoi_poly sf polygon object representing the area of interest
-  #' @param buffer_dist_m integer; indicates the distance in meters to buffer 
-  #' around the area of interest polygon. See ??sf::st_buffer for further details.
+  #' @param dist_m integer; grid geometries will be returned if distances between
+  #' the grid polygons and the aoi polygon are smaller or equal to this value.
   #' 
   #' @value returns an sf polygon object containing the geometries for each box 
   #' within the holistic grid that overlaps the buffered area of interest.
   #' 
-  #' @example subset_grids_to_aoi(grid = p1_conus_grid, buffer_dist_m = 5000)
+  #' @example subset_grids_to_aoi(grid = p1_conus_grid, dist_m = 5000)
   #' 
   
-  # Project area of interest to calculate buffer and set up for intersection
-  buffered_aoi <- aoi_poly %>%
-    sf::st_transform(5070) %>%
-    sf::st_buffer(5000)
-  
-  # Filter the big grid of boxes to only include those that overlap
-  # with the buffered area of interest
+  # Filter the big grid of boxes to only include those that overlap/are within
+  # a given distance of the area of interest
   grid_subset_aoi <- grid %>%
-    sf::st_transform(5070) %>%
-    sf::st_filter(y = buffered_aoi,
-                  .predicate = st_intersects)  
+    sf::st_filter(y = sf::st_transform(aoi_poly,sf::st_crs(grid)),
+                  .predicate = st_is_within_distance,dist=units::set_units(dist_m, m))   
   
   return(grid_subset_aoi)
   

--- a/1_fetch/src/create_grids.R
+++ b/1_fetch/src/create_grids.R
@@ -4,7 +4,8 @@ create_conus_grid <- function(cellsize, year = 2020, progress_bar = FALSE){
   #' data queries
   #' 
   #' @param cellsize the target cell size of each box in map units (here, degrees);
-  #' see ??sf::st_make_grid for further details.
+  #' takes two values indicating the size in the x direction and the size in the 
+  #' y direction, see ??sf::st_make_grid for further details.
   #' @param year integer; year of the state polygon data download (defaults to 2020); 
   #' see ??tigris::states for further details.
   #' @param progress_bar logical; indicates whether a progress bar showing the status

--- a/1_fetch/src/create_grids.R
+++ b/1_fetch/src/create_grids.R
@@ -1,22 +1,24 @@
+#' Create CONUS grid
+#' 
+#' @description Function to create a big grid of boxes to use for chunked
+#' data queries
+#' 
+#' @param cellsize the target cell size of each box in map units (here, degrees);
+#' takes two values indicating the size in the x direction and the size in the 
+#' y direction, see ??sf::st_make_grid for further details.
+#' @param year integer; year of the state polygon data download (defaults to 2020); 
+#' see ??tigris::states for further details.
+#' @param progress_bar logical; indicates whether a progress bar showing the status
+#' of the state polygon build should be returned (defaults to FALSE)
+#' 
+#' @value returns an sf polygon object containing the geometries and an attribute 
+#' id for each box within the CONUS grid.
+#' 
+#' @example create_conus_grid(cellsize = c(1,1))
+#' 
+
 create_conus_grid <- function(cellsize, year = 2020, progress_bar = FALSE){
-  #' 
-  #' @description Function to create a big grid of boxes to use for chunked
-  #' data queries
-  #' 
-  #' @param cellsize the target cell size of each box in map units (here, degrees);
-  #' takes two values indicating the size in the x direction and the size in the 
-  #' y direction, see ??sf::st_make_grid for further details.
-  #' @param year integer; year of the state polygon data download (defaults to 2020); 
-  #' see ??tigris::states for further details.
-  #' @param progress_bar logical; indicates whether a progress bar showing the status
-  #' of the state polygon build should be returned (defaults to FALSE)
-  #' 
-  #' @value returns an sf polygon object containing the geometries and an attribute 
-  #' id for each box within the CONUS grid.
-  #' 
-  #' @example create_conus_grid(cellsize = c(1,1))
-  #'  
-  
+ 
   conus_grid <- tigris::states(class = "sf", year = year, progress_bar = progress_bar) %>%
     # filter state polygons to CONUS extent
     filter(REGION != "9", 
@@ -33,23 +35,26 @@ create_conus_grid <- function(cellsize, year = 2020, progress_bar = FALSE){
 
 
 
+#' Subset grid to AOI
+#' 
+#' @description Function to spatially subset a holistic grid of boxes
+#' to find the boxes that overlap the area of interest. The area of 
+#' interest is buffered to ensure that all overlapping boxes are returned.
+#' 
+#' @param grid sf polygon object containing the geometries and an attribute 
+#' id for each box within the grid.
+#' @param aoi_poly sf polygon object representing the area of interest
+#' @param dist_m integer; grid geometries will be returned if distances between
+#' the grid polygons and the aoi polygon are smaller or equal to this value.
+#' 
+#' @value returns an sf polygon object containing the geometries for each box 
+#' within the holistic grid that overlaps the buffered area of interest.
+#' 
+#' @example subset_grids_to_aoi(grid = p1_conus_grid, dist_m = 5000)
+#' 
+
 subset_grids_to_aoi <- function(grid, aoi_poly, dist_m){
-  #' 
-  #' @description Function to spatially subset a holistic grid of boxes
-  #' to find the boxes that overlap the area of interest. The area of 
-  #' interest is buffered to ensure that all overlapping boxes are returned.
-  #' 
-  #' @param grid sf polygon object containing the geometries and an attribute 
-  #' id for each box within the grid.
-  #' @param aoi_poly sf polygon object representing the area of interest
-  #' @param dist_m integer; grid geometries will be returned if distances between
-  #' the grid polygons and the aoi polygon are smaller or equal to this value.
-  #' 
-  #' @value returns an sf polygon object containing the geometries for each box 
-  #' within the holistic grid that overlaps the buffered area of interest.
-  #' 
-  #' @example subset_grids_to_aoi(grid = p1_conus_grid, dist_m = 5000)
-  #' 
+
   
   # Filter the big grid of boxes to only include those that overlap/are within
   # a given distance of the area of interest

--- a/1_fetch/src/create_grids.R
+++ b/1_fetch/src/create_grids.R
@@ -1,0 +1,68 @@
+create_conus_grid <- function(cellsize, year = 2020, progress_bar = FALSE){
+  #' 
+  #' @description Function to create a big grid of boxes to use for chunked
+  #' data queries
+  #' 
+  #' @param cellsize the target cell size of each box in map units (here, degrees);
+  #' see ??sf::st_make_grid for further details.
+  #' @param year integer; year of the state polygon data download (defaults to 2020); 
+  #' see ??tigris::states for further details.
+  #' @param progress_bar logical; indicates whether a progress bar showing the status
+  #' of the state polygon build should be returned (defaults to FALSE)
+  #' 
+  #' @value returns an sf polygon object containing the geometries and an attribute 
+  #' id for each box within the CONUS grid.
+  #' 
+  #' @example create_conus_grid(cellsize = c(1,1))
+  #'  
+  
+  conus_grid <- tigris::states(class = "sf", year = year, progress_bar = progress_bar) %>%
+    # filter state polygons to CONUS extent
+    filter(REGION != "9", 
+           !STUSPS %in% c("HI","AK")) %>%
+    # create square grid with cell sizes equal to 1 deg. x 1 deg.
+    sf::st_make_grid(cellsize = c(cellsize[1],cellsize[2]), square = TRUE) %>%
+    # convert to sf object and add an "id" attribute
+    sf::st_as_sf() %>%
+    mutate(id = row.names(.))
+  
+  return(conus_grid)
+  
+}
+
+
+
+subset_grids_to_aoi <- function(grid, aoi_poly, buffer_dist_m){
+  #' 
+  #' @description Function to spatially subset a holistic grid of boxes
+  #' to find the boxes that overlap the area of interest. The area of 
+  #' interest is buffered to ensure that all overlapping boxes are returned.
+  #' 
+  #' @param grid sf polygon object containing the geometries and an attribute 
+  #' id for each box within the grid.
+  #' @param aoi_poly sf polygon object representing the area of interest
+  #' @param buffer_dist_m integer; indicates the distance in meters to buffer 
+  #' around the area of interest polygon. See ??sf::st_buffer for further details.
+  #' 
+  #' @value returns an sf polygon object containing the geometries for each box 
+  #' within the holistic grid that overlaps the buffered area of interest.
+  #' 
+  #' @example subset_grids_to_aoi(grid = p1_conus_grid, buffer_dist_m = 5000)
+  #' 
+  
+  # Project area of interest to calculate buffer and set up for intersection
+  buffered_aoi <- aoi_poly %>%
+    sf::st_transform(5070) %>%
+    sf::st_buffer(5000)
+  
+  # Filter the big grid of boxes to only include those that overlap
+  # with the buffered area of interest
+  grid_subset_aoi <- grid %>%
+    sf::st_transform(5070) %>%
+    sf::st_filter(y = buffered_aoi,
+                  .predicate = st_intersects)  
+  
+  return(grid_subset_aoi)
+  
+}
+

--- a/_targets.R
+++ b/_targets.R
@@ -1,7 +1,7 @@
 library(targets)
 
 options(tidyverse.quiet = TRUE)
-tar_option_set(packages = c('tidyverse', 'lubridate', 'dataRetrieval', 'sf'))
+tar_option_set(packages = c('tidyverse', 'lubridate', 'dataRetrieval', 'sf', 'tigris'))
 
 source("1_fetch.R")
 


### PR DESCRIPTION
Addresses #10.

This PR creates a big, CONUS-scale grid that can be used to chunk data queries to WQP. One target (`p1_conus_grid`) creates the grid and another target (`p1_overlapping_boxes`) subsets the big grid to find those boxes that overlap with a buffered version of our AOI polygon. I plan on using dynamic branching to map the WQP data queries over the boxes within `p1_overlapping_boxes`.

I'm open to any feedback you have here, including target names, documentation, etc. I considered moving the code to build `p1_conus_grid` to a separate function to clean up the fetch phase file, so let me know if you have any thoughts on that. Thanks in advance!

Here's what our pipeline looks like including the changes in this PR:

![pipeline_makegrid](https://user-images.githubusercontent.com/8785034/159369781-5066d6ab-9358-4e46-a590-8bc627a78c10.png)

And here's a preview of the output:

![boxes](https://user-images.githubusercontent.com/8785034/159370194-a0a90c36-0f1d-46d7-9be9-40a0a1a08496.png)


