### PR TITLE
Add wqp inventory

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -55,14 +55,16 @@ p1_targets_list <- list(
     subset_grids_to_aoi(p1_conus_grid, p1_AOI_sf, dist_m = 5000)
   ),
   
-  # Inventory data available from the WQP within the area of interest.
-  # To prevent timeout issues that result from large data requests, use
-  # {targets}' dynamic branching capabilities to map the inventory_wqp()
-  # function over each grid within p1_conus_grid_aoi_bbox. {targets} will
-  # then combine all of the grid-scale inventories into one table when
-  # building p1_wqp_inventory.
+  # Inventory data available from the WQP within the area of interest. To
+  # prevent timeout issues that result from large data requests, use {targets}
+  # dynamic branching capabilities to map inventory_wqp() over each grid within
+  # p1_conus_grid_aoi_bbox. {targets} will then combine all of the grid-scale 
+  # inventories into one table when building p1_wqp_inventory.
   tar_target(
     p1_wqp_inventory,
+    # inventory_wqp() requires grid and char_names as inputs, but users
+    # can also pass additional arguments, e.g. sampleMedia or siteType.
+    # See documentation in 1_fetch/src/get_wqp_inventory.R for details.
     inventory_wqp(grid = p1_conus_grid_aoi,
                   char_names = p1_charNames,
                   sampleMedia = "Water",

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -55,6 +55,12 @@ p1_targets_list <- list(
     subset_grids_to_aoi(p1_conus_grid, p1_AOI_sf, dist_m = 5000)
   ),
   
+  # Return bounding boxes for grids that overlap the area of interest
+  tar_target(
+    p1_conus_grid_aoi_bbox,
+    return_bbox(p1_conus_grid_aoi)
+  ),
+  
   # Inventory data available from the WQP within the area of interest.
   # To prevent timeout issues that result from large data requests, use
   # {targets}' dynamic branching capabilities to map the inventory_wqp()
@@ -63,7 +69,8 @@ p1_targets_list <- list(
   # building p1_wqp_inventory.
   tar_target(
     p1_wqp_inventory,
-    inventory_wqp(p1_conus_grid_aoi,"Conductivity", "Stream")
+    inventory_wqp(p1_conus_grid_aoi_bbox,"Conductivity", "Stream"),
+    pattern = map(p1_conus_grid_aoi_bbox)
   )
 
 )

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -64,12 +64,14 @@ p1_targets_list <- list(
   # Inventory data available from the WQP within the area of interest.
   # To prevent timeout issues that result from large data requests, use
   # {targets}' dynamic branching capabilities to map the inventory_wqp()
-  # function over each grid within p1_conus_grid_aoi. {Targets} will
+  # function over each grid within p1_conus_grid_aoi_bbox. {Targets} will
   # then combine all of the grid-scale inventories into one table when
   # building p1_wqp_inventory.
   tar_target(
     p1_wqp_inventory,
-    inventory_wqp(p1_conus_grid_aoi_bbox,"Conductivity", "Stream"),
+    inventory_wqp(p1_conus_grid_aoi_bbox,
+                  unlist(p1_charNames),
+                  "Stream"),
     pattern = map(p1_conus_grid_aoi_bbox)
   )
 

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -55,10 +55,12 @@ p1_targets_list <- list(
     subset_grids_to_aoi(p1_conus_grid, p1_AOI_sf, dist_m = 5000)
   ),
   
-  # Return bounding boxes for grids that overlap the area of interest
+  # Return bounding boxes for grids that overlap the area of interest;
+  # returns an object target of class "list".
   tar_target(
     p1_conus_grid_aoi_bbox,
-    return_bbox(p1_conus_grid_aoi)
+    return_bbox(p1_conus_grid_aoi),
+    iteration = "list"
   ),
   
   # Inventory data available from the WQP within the area of interest.
@@ -69,9 +71,9 @@ p1_targets_list <- list(
   # building p1_wqp_inventory.
   tar_target(
     p1_wqp_inventory,
-    inventory_wqp(p1_conus_grid_aoi_bbox,
-                  unlist(p1_charNames),
-                  "Stream"),
+    inventory_wqp(bbox = p1_conus_grid_aoi_bbox,
+                  char_names = unlist(p1_charNames),
+                  site_type = "Stream"),
     pattern = map(p1_conus_grid_aoi_bbox)
   )
 

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -64,8 +64,9 @@ p1_targets_list <- list(
   tar_target(
     p1_wqp_inventory,
     inventory_wqp(grid = p1_conus_grid_aoi,
-                  char_names = unlist(p1_charNames),
-                  site_type = "Stream"),
+                  char_names = p1_charNames,
+                  sampleMedia = "Water",
+                  siteType = "Stream"),
     pattern = map(p1_conus_grid_aoi)
   )
 

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -55,26 +55,18 @@ p1_targets_list <- list(
     subset_grids_to_aoi(p1_conus_grid, p1_AOI_sf, dist_m = 5000)
   ),
   
-  # Return bounding boxes for grids that overlap the area of interest;
-  # returns an object target of class "list".
-  tar_target(
-    p1_conus_grid_aoi_bbox,
-    return_bbox(p1_conus_grid_aoi),
-    iteration = "list"
-  ),
-  
   # Inventory data available from the WQP within the area of interest.
   # To prevent timeout issues that result from large data requests, use
   # {targets}' dynamic branching capabilities to map the inventory_wqp()
-  # function over each grid within p1_conus_grid_aoi_bbox. {Targets} will
+  # function over each grid within p1_conus_grid_aoi_bbox. {targets} will
   # then combine all of the grid-scale inventories into one table when
   # building p1_wqp_inventory.
   tar_target(
     p1_wqp_inventory,
-    inventory_wqp(bbox = p1_conus_grid_aoi_bbox,
+    inventory_wqp(grid = p1_conus_grid_aoi,
                   char_names = unlist(p1_charNames),
                   site_type = "Stream"),
-    pattern = map(p1_conus_grid_aoi_bbox)
+    pattern = map(p1_conus_grid_aoi)
   )
 
 )

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -1,5 +1,6 @@
 # Source the functions that will be used to build the targets in p1_targets_list
 source("1_fetch/src/create_grids.R")
+source("1_fetch/src/get_wqp_inventory.R")
 
 p1_targets_list <- list(
   
@@ -52,6 +53,17 @@ p1_targets_list <- list(
   tar_target(
     p1_conus_grid_aoi,
     subset_grids_to_aoi(p1_conus_grid, p1_AOI_sf, dist_m = 5000)
+  ),
+  
+  # Inventory data available from the WQP within the area of interest.
+  # To prevent timeout issues that result from large data requests, use
+  # {targets}' dynamic branching capabilities to map the inventory_wqp()
+  # function over each grid within p1_conus_grid_aoi. {Targets} will
+  # then combine all of the grid-scale inventories into one table when
+  # building p1_wqp_inventory.
+  tar_target(
+    p1_wqp_inventory,
+    inventory_wqp(p1_conus_grid_aoi,"Conductivity", "Stream")
   )
 
 )

--- a/1_fetch/src/create_grids.R
+++ b/1_fetch/src/create_grids.R
@@ -66,3 +66,26 @@ subset_grids_to_aoi <- function(grid, aoi_poly, dist_m){
   
 }
 
+
+
+#' Return bounding box as a vector
+#' 
+#' @description Function to find the bounding box for an sf object and return
+#' as a vector
+#' 
+#' @param grid sf polygon object containing the geometries and an attribute
+#' id for each box within the grid
+#' 
+
+return_bbox <- function(grid){
+  
+  bbox_tbl <- grid %>%
+    mutate(bbox = lapply(x, sf::st_bbox)) %>%
+    sf::st_drop_geometry() %>%
+    bind_rows() 
+  
+  return(bbox_tbl)
+  
+}
+
+

--- a/1_fetch/src/create_grids.R
+++ b/1_fetch/src/create_grids.R
@@ -70,7 +70,7 @@ subset_grids_to_aoi <- function(grid, aoi_poly, dist_m){
 
 #' Return bounding box as a vector
 #' 
-#' @description Function to find the bounding box for an sf object and return
+#' @description Function to find the bounding box for an sf object(s) and return
 #' as a vector
 #' 
 #' @param grid sf polygon object containing the geometries and an attribute
@@ -79,12 +79,10 @@ subset_grids_to_aoi <- function(grid, aoi_poly, dist_m){
 
 return_bbox <- function(grid){
   
-  bbox_tbl <- grid %>%
-    mutate(bbox = lapply(x, sf::st_bbox)) %>%
-    sf::st_drop_geometry() %>%
-    bind_rows() 
+  bbox <- lapply(sf::st_geometry(grid), sf::st_bbox) %>% 
+    setNames(grid$id)
   
-  return(bbox_tbl)
+  return(bbox)
   
 }
 

--- a/1_fetch/src/get_wqp_inventory.R
+++ b/1_fetch/src/get_wqp_inventory.R
@@ -2,7 +2,8 @@
 #' 
 #' @description Function to inventory WQP sites and observations within the area of interest
 #' 
-#' @param aoi sf object representing the area of interest
+#' @param bbox_tbl data frame containing an attribute id and bounding box for each
+#' box sampled within the area of interest. The column bbox is of class list.
 #' @param char_names character string indicating the WQP CharacteristicNames to query
 #' @param site_type character string indicating which water feature type(s) to query
 #' @param year_earliest integer; the earliest year to include in the returned inventory,
@@ -16,10 +17,10 @@
 #' @example inventory_wqp(aoi_poly, "Temperature", "Lake, Reservoir, Impoundment")
 #' 
 
-inventory_wqp <- function(aoi, char_names, site_type, year_earliest = NULL, year_latest = NULL){
+inventory_wqp <- function(bbox_tbl, char_names, site_type, year_earliest = NULL, year_latest = NULL){
   
   # Return bounding box to use for WQP data summary
-  bbox <- sf::st_bbox(aoi)
+  bbox <- bbox_tbl$bbox[[1]]
   
   # Inventory available WQP data
   wqp_inventory <- dataRetrieval::readWQPsummary(

--- a/1_fetch/src/get_wqp_inventory.R
+++ b/1_fetch/src/get_wqp_inventory.R
@@ -13,14 +13,11 @@
 #' 
 #' @value returns a list of sites from the Water Quality Portal
 #' 
-#' @example inventory_wqp(aoi_poly, "Conductivity", "Stream")
-#' @example inventory_wqp(aoi_poly, "Temperature", "Lake, Reservoir, Impoundment")
+#' @example inventory_wqp(aoi_bbox, "Conductivity", "Stream")
+#' @example inventory_wqp(aoi_bbox, "Temperature", "Lake, Reservoir, Impoundment")
 #' 
 
-inventory_wqp <- function(bbox_tbl, char_names, site_type, year_earliest = NULL, year_latest = NULL){
-  
-  # Return bounding box to use for WQP data summary
-  bbox <- bbox_tbl$bbox[[1]]
+inventory_wqp <- function(bbox, char_names, site_type, year_earliest = NULL, year_latest = NULL){
   
   # Inventory available WQP data
   wqp_inventory <- dataRetrieval::readWQPsummary(

--- a/1_fetch/src/get_wqp_inventory.R
+++ b/1_fetch/src/get_wqp_inventory.R
@@ -1,0 +1,45 @@
+#' Inventory WQP within area of interest
+#' 
+#' @description Function to inventory WQP sites and observations within the area of interest
+#' 
+#' @param aoi sf object representing the area of interest
+#' @param char_names character string indicating the WQP CharacteristicNames to query
+#' @param site_type character string indicating which water feature type(s) to query
+#' @param year_earliest integer; the earliest year to include in the returned inventory,
+#' defaults to NULL, which returns all available years
+#' @param year_latest integer; the most recent year to include in the returned inventory,
+#' defaults to NULL, which returns all available years
+#' 
+#' @value returns a list of sites from the Water Quality Portal
+#' 
+#' @example inventory_wqp(aoi_poly, "Conductivity", "Stream")
+#' @example inventory_wqp(aoi_poly, "Temperature", "Lake, Reservoir, Impoundment")
+#' 
+
+inventory_wqp <- function(aoi, char_names, site_type, year_earliest = NULL, year_latest = NULL){
+  
+  # Return bounding box to use for WQP data summary
+  bbox <- sf::st_bbox(aoi)
+  
+  # Inventory available WQP data
+  wqp_inventory <- dataRetrieval::readWQPsummary(
+    bBox = c(bbox$xmin, bbox$ymin, bbox$xmax, bbox$ymax),
+    summaryYears = "all",
+    siteType = site_type)
+  
+  # Format WQP inventory and subset years of interest
+  wqp_inventory_out <- wqp_inventory %>%
+    select(MonitoringLocationIdentifier, YearSummarized, OrganizationIdentifier, 
+           CharacteristicName, MonitoringLocationLongitude, 
+           MonitoringLocationLatitude, ResultCount) %>%
+    rename(lon = MonitoringLocationLongitude, 
+           lat = MonitoringLocationLatitude) %>%
+    filter(CharacteristicName %in% char_names) %>%
+    filter(if(!is.null(year_earliest)) YearSummarized >= year_earliest else TRUE) %>%
+    filter(if(!is.null(year_latest)) YearSummarized <= year_latest else TRUE) 
+  
+  return(wqp_inventory_out)
+  
+}
+
+

--- a/1_fetch/src/get_wqp_inventory.R
+++ b/1_fetch/src/get_wqp_inventory.R
@@ -3,43 +3,47 @@
 #' @description Function to inventory WQP sites and observations within the area of interest
 #' 
 #' @param grid sf object representing the area over which to query the WQP
-#' @param char_names character string indicating the WQP CharacteristicNames to query
-#' @param site_type character string indicating which water feature type(s) to query
-#' @param year_earliest integer; the earliest year to include in the returned inventory,
-#' defaults to NULL, which returns all available years
-#' @param year_latest integer; the most recent year to include in the returned inventory,
-#' defaults to NULL, which returns all available years
+#' @param char_names character string or list of character strings indicating the 
+#' WQP CharacteristicNames to query
+#' @param ... see  https://www.waterqualitydata.us/webservices_documentation for more 
+#' information on the options accepted by dataRetrieval::whatWQPdata().
 #' 
 #' @value returns a list of sites from the Water Quality Portal
 #' 
-#' @example inventory_wqp(aoi_bbox, "Conductivity", "Stream")
-#' @example inventory_wqp(aoi_bbox, "Temperature", "Lake, Reservoir, Impoundment")
+#' @example inventory_wqp(aoi_bbox, "Conductivity", siteType = "Stream")
+#' @example inventory_wqp(aoi_bbox, "Temperature", siteType = "Lake, Reservoir, Impoundment")
 #' 
 
-inventory_wqp <- function(grid, char_names, site_type, year_earliest = NULL, year_latest = NULL){
+inventory_wqp <- function(grid, char_names, ...){
   
   # Get bounding box for the grid polygon
   bbox <- sf::st_bbox(grid)
   
+  # Format characteristic names
+  char_names <- as.character(unlist(char_names))
+  
+  # Print time-specific message so user can see progress
+  message(sprintf('Retrieving whatWQPdata for grid %s...', grid$id))
+
   # Inventory available WQP data
-  wqp_inventory <- dataRetrieval::readWQPsummary(
-    bBox = c(bbox$xmin, bbox$ymin, bbox$xmax, bbox$ymax),
-    summaryYears = "all",
-    siteType = site_type)
+  wqp_inventory <- lapply(char_names,function(x){
+    dataRetrieval::whatWQPdata(
+      bBox = c(bbox$xmin, bbox$ymin, bbox$xmax, bbox$ymax),
+      characteristicName = x,
+      ...) %>%
+      mutate(CharacteristicName = x)
+  }) %>%
+    bind_rows()
   
-  # Format WQP inventory and subset years of interest
+  # Format WQP inventory 
   wqp_inventory_out <- wqp_inventory %>%
-    select(MonitoringLocationIdentifier, YearSummarized, OrganizationIdentifier, 
-           CharacteristicName, MonitoringLocationLongitude, 
-           MonitoringLocationLatitude, ResultCount) %>%
-    rename(lon = MonitoringLocationLongitude, 
-           lat = MonitoringLocationLatitude) %>%
-    filter(CharacteristicName %in% char_names) %>%
-    filter(if(!is.null(year_earliest)) YearSummarized >= year_earliest else TRUE) %>%
-    filter(if(!is.null(year_latest)) YearSummarized <= year_latest else TRUE) 
-  
+    group_by(CharacteristicName) %>%
+    summarize(sites_count = n(),
+              results_count = sum(resultCount)) %>%
+    mutate(grid_id = grid$id) %>%
+    select(grid_id, CharacteristicName, sites_count, results_count)
+
   return(wqp_inventory_out)
   
 }
-
 

--- a/1_fetch/src/get_wqp_inventory.R
+++ b/1_fetch/src/get_wqp_inventory.R
@@ -2,8 +2,7 @@
 #' 
 #' @description Function to inventory WQP sites and observations within the area of interest
 #' 
-#' @param bbox_tbl data frame containing an attribute id and bounding box for each
-#' box sampled within the area of interest. The column bbox is of class list.
+#' @param grid sf object representing the area over which to query the WQP
 #' @param char_names character string indicating the WQP CharacteristicNames to query
 #' @param site_type character string indicating which water feature type(s) to query
 #' @param year_earliest integer; the earliest year to include in the returned inventory,
@@ -17,7 +16,10 @@
 #' @example inventory_wqp(aoi_bbox, "Temperature", "Lake, Reservoir, Impoundment")
 #' 
 
-inventory_wqp <- function(bbox, char_names, site_type, year_earliest = NULL, year_latest = NULL){
+inventory_wqp <- function(grid, char_names, site_type, year_earliest = NULL, year_latest = NULL){
+  
+  # Get bounding box for the grid polygon
+  bbox <- sf::st_bbox(grid)
   
   # Inventory available WQP data
   wqp_inventory <- dataRetrieval::readWQPsummary(


### PR DESCRIPTION
The goal here is to add a target `p1_wqp_inventory` that inventories data from the Water Quality Portal over the area of interest (before downloading that data in a downstream step). 

I'm hoping to also use this PR to collectively brainstorm some open questions about the pipeline structure:

- Previously, we created a "big grid" that we then subset to those boxes that overlap our area of interest. These boxes can be used to chunk WQP calls into smaller queries, and my approach here assumes we will generate target branches over space. #19
- I've opted to use dynamic branching for mapping `inventory_wqp()` over each of the boxes because I think dynamic branching is more readily transferable to other users' applications. I also personally find dynamic branching more intuitive than static branching since its conceptually similar to other R functions used in the split-apply-combine style of workflow. #18
- Here I limited our site types to only include "Streams" but I'm open to any suggestions or ideas for making our pipeline useful to a broad group of users . #20

You'll notice that I created an intermediate target `p1_conus_grid_aoi_bbox`, a data frame that contains the bounding boxes for each of our overlapping boxes in `p1_conus_grid_aoi`. I had intended on creating target branches from `p1_conus_grid_aoi` directly, but got warnings from {targets} that the input must be a vector (not an sf/sfc polygon) 😮. I'd be curious to hear any suggestions you have for branching over space and/or to clean up the pipeline steps to account for this behavior (e.g. merge `p1_conus_grid_aoi` and `p1_conus_grid_aoi_bbox` into one target?). 

Finally, `p1_wqp_inventory` currently returns information about each site within the inventory (see snippet below). I went back and forth on what I thought was more useful - this sort of inventory where a user could poke around the sites and perhaps do some further data manipulation, or a "sparse" version that includes the # of sites and samples for each requested characteristicName. Do you have any thoughts on that?

```
> tar_load(p1_wqp_inventory)
> head(p1_wqp_inventory)
# A tibble: 6 x 7
  MonitoringLocationIdentifier YearSummarized OrganizationIdentifier CharacteristicName   lon         lat        ResultCount
  <chr>                                 <dbl> <chr>                  <chr>                <chr>       <chr>            <dbl>
1 USGS-01495480                          1982 USGS-MD                Specific conductance -75.8863301 39.7009443           2
2 USGS-01495480                          1982 USGS-MD                Temperature, water   -75.8863301 39.7009443           1
3 USGS-01495500                          1966 USGS-MD                Specific conductance -75.8663290 39.6417786           1
4 USGS-01495500                          1966 USGS-MD                Temperature, water   -75.8663290 39.6417786           1
5 USGS-01495500                          1974 USGS-MD                Specific conductance -75.8663290 39.6417786           8
6 USGS-01495500                          1974 USGS-MD                Temperature, water   -75.8663290 39.6417786           8
> 
```

Thanks!


