### PR TITLE
Check whether characteristic names are valid

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -19,7 +19,7 @@ p1_targets_list <- list(
   
   # Get a vector of WQP characteristicNames to match parameter groups of interest
   tar_target(
-    p1_charNames,
+    p1_char_names,
     filter_characteristics(p1_wqp_params, param_groups_select)
   ),
   
@@ -67,7 +67,7 @@ p1_targets_list <- list(
     # can also pass additional arguments, e.g. sampleMedia or siteType.
     # See documentation in 1_fetch/src/get_wqp_inventory.R for details.
     inventory_wqp(grid = p1_conus_grid_aoi,
-                  char_names = p1_charNames,
+                  char_names = p1_char_names,
                   sampleMedia = "Water",
                   siteType = "Stream"),
     pattern = map(p1_conus_grid_aoi)

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -1,4 +1,5 @@
 # Source the functions that will be used to build the targets in p1_targets_list
+source("1_fetch/src/check_characteristics.R")
 source("1_fetch/src/create_grids.R")
 source("1_fetch/src/get_wqp_inventory.R")
 
@@ -19,7 +20,7 @@ p1_targets_list <- list(
   # Get a vector of WQP characteristicNames to match parameter groups of interest
   tar_target(
     p1_charNames,
-    p1_wqp_params[param_groups_select]
+    filter_characteristics(p1_wqp_params, param_groups_select)
   ),
   
   # Define the spatial area of interest (AOI) for the WQP data pull

--- a/1_fetch/src/check_characteristics.R
+++ b/1_fetch/src/check_characteristics.R
@@ -1,0 +1,63 @@
+#' Function to read all valid characteristic names from WQP web service
+#' 
+#' @return vector of character strings representing all of the valid
+#' characteristic names from WQP
+#' 
+read_wqp_characteristics <- function(){
+  
+  # Fetch all characteristics from WQP
+  all_characteristic_names <- xml2::read_xml("https://www.waterqualitydata.us/Codes/Characteristicname?mimeType=xml") %>% 
+    xml2::xml_children() %>% xml2::xml_attr("value") %>% na.omit()
+  
+  return(all_characteristic_names)
+}
+
+
+#' Function to check whether all user-specified characteristics are valid.
+#' 
+#' @param chars vector of character strings representing which characteristic
+#' names to check against valid entries in the WQP.
+#' 
+#' @return logical statement for each string within supplied characteristics list;
+#' if any characteristics are not valid, a printed message will indicate which 
+#' characteristics do not exist in WQP. 
+#' @example check_valid_characteristics(c("Specific conductivity", "Specific conductance"))
+#' 
+check_valid_characteristics <- function(chars) {
+  
+  # Fetch all WQP characteristics and test whether each user-supplied characteristic
+  # name is within the list of valid entries from WQP
+  all_characteristic_names <- read_wqp_characteristics()
+  chars_exist <- chars %in% all_characteristic_names
+  
+  if(!all(chars_exist)) {
+    message(sprintf("The following characteristics do not exist in WQP:\n\n%s\n",
+                    paste(chars[which(!chars_exist)], collapse="\n")))
+  }
+  
+  return(chars_exist)
+}
+
+
+#' Function to filter WQP parameters and associated characteristic names from a 
+#' general configuration file to only include the selected parameter groups of 
+#' interest for the data pull. 
+#' 
+#' @param wqp_params list containing data frames corresponding to various parameter
+#' groups of interest. Each parameter data frame contains a vector of character
+#' strings representing known WQP characteristic names associated with each 
+#' parameter. 
+#' @param param_groups_select character string indicating what parameter groups will
+#' be used for the WQP data pull.
+#' 
+filter_characteristics <- function(wqp_params, param_groups_select){
+  
+  # Create character string containing desired characteristic names
+  characteristics_select <- as.character(unlist(wqp_params[param_groups_select]))
+  
+  # Return desired characteristic names that represent valid WQP characteristics
+  characteristics_in_wqp <- characteristics_select[check_valid_characteristics(characteristics_select)]
+  
+  return(characteristics_in_wqp)
+}
+

--- a/_targets.R
+++ b/_targets.R
@@ -1,7 +1,8 @@
 library(targets)
 
 options(tidyverse.quiet = TRUE)
-tar_option_set(packages = c('tidyverse', 'lubridate', 'dataRetrieval', 'sf', 'tigris'))
+tar_option_set(packages = c('tidyverse', 'lubridate', 'dataRetrieval', 
+                            'sf', 'tigris', 'xml2'))
 
 source("1_fetch.R")
 


### PR DESCRIPTION
Addresses #26.

This PR adds several new functions in `1_fetch/src/check_characteristics.R` to take the list of characteristics from the WQP codes cfg file and check whether each characteristic name is a valid entry in WQP.  One of the functions is `read_wqp_characteristics()` from @lindsayplatt's proxies example files. I've intentionally made these functions small in scope because I anticipate using `read_wqp_characteristics` again when addressing #24.

The changes here also include renaming the characteristics target (originally `p1_charNames`) to `p1_char_names` to conform with the snake_case formatting we use throughout the pipeline. On my local clone I ran `tar_invalidate(p1_charNames)` to remove the old target from tar_meta. Do you know of any other steps that should be taken when renaming/deleting a target?
