### PR TITLE
Write log file containing similar characteristic names

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -23,6 +23,14 @@ p1_targets_list <- list(
     filter_characteristics(p1_wqp_params, param_groups_select)
   ),
   
+  # Save log file containing WQP characteristic names that are similar to the
+  # parameter groups of interest
+  tar_target(
+    p1_similar_char_names_txt,
+    find_similar_characteristics(p1_char_names, param_groups_select, "1_fetch/out"),
+    format = "file"
+  ),
+  
   # Define the spatial area of interest (AOI) for the WQP data pull
   # This target could also be edited to read in coordinates from a local file
   # that contains the columns 'lon' and 'lat', e.g. replace data.frame() with 

--- a/1_fetch/src/check_characteristics.R
+++ b/1_fetch/src/check_characteristics.R
@@ -61,3 +61,50 @@ filter_characteristics <- function(wqp_params, param_groups_select){
   return(characteristics_in_wqp)
 }
 
+
+#' Function to search a list of valid WQP characteristic names and find valid
+#' characteristic names that are similar to the parameters requested.
+#' 
+#' @param characteristics_select character string of desired characteristic names 
+#' identified from the wqp codes cfg file
+#' @param param_groups_select character string indicating what parameter groups 
+#' will be used for the WQP data pull
+#' @param save_dir file path indicating where log files containing similar 
+#' characteristic names should be saved
+#' 
+#' @return saves one .txt file for each parameter in param_groups_select. The saved 
+#' file(s) indicates valid characteristic names in WQP that are similar to that 
+#' parameter, and indicates which entries are already included in the cfg file and
+#' which entries are not. Those entries not already included in the cfg file are 
+#' meant to provide a quick reference for additional characteristic names that 
+#' might warrant further consideration. 
+#' 
+find_similar_characteristics <- function(characteristics_select, param_groups_select, save_dir){
+  
+  # Read in characteristic names from WQP
+  characteristics_all <- read_wqp_characteristics()
+  
+  # For each parameter group, search for approximate string matches
+  # within list of WQP characteristic names
+  matched_characteristics <- lapply(param_groups_select,function(x){
+    
+    message(sprintf("Searching for other WQP characteristics that may belong to parameter: %s",x))
+    
+    matched_chars <- agrep(x, characteristics_all,
+                           value = TRUE, ignore.case = TRUE)
+    matched_chars_selected <- matched_chars[matched_chars %in% characteristics_select]
+    matched_chars_not_selected <- matched_chars[!matched_chars %in% characteristics_select]
+    
+    header_selected <- "The following characteristics are already included in the WQP codes cfg file: "
+    header_not_selected <- "The following characteristics might be relevant to the selected parameter and are not included in the WQP codes cfg file: "
+    out_file <- paste0(save_dir,"/wqp_characteristics_",x,".txt")
+    writeLines(c(header_selected,matched_chars_selected,"\n",
+                 header_not_selected, matched_chars_not_selected),
+               sep = "\n" ,out_file)
+    return(out_file)
+  })
+  
+  return(unlist(matched_characteristics))
+}
+
+


### PR DESCRIPTION
Addresses #24.

The code changes here add a new target (`p1_similar_char_names_txt`) that uses approximate string matching to find valid characteristic names in WQP that are _similar_ to each parameter group of interest. The output log files are not meant to be conclusive - and likely contain some extraneous  characteristic names - but rather, to narrow down the list of options and provide a quick reference for alternative characteristic names that might warrant further inspection/manual follow-up.

