### PR TITLE
Pull WQP data based on inventory

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -99,14 +99,17 @@ p1_targets_list <- list(
   # Group the sites into reasonably sized chunks for downloading data 
   tar_target(
     p1_site_ids_grouped,
-    add_download_groups(p1_site_ids, max_sites_allowed = 500)
+    add_download_groups(p1_site_ids, max_sites_allowed = 500) %>%
+      group_by(download_grp) %>%
+      tar_group(),
+    iteration = "group"
   ),
 
-  # Download data using output of WQP inventory  
+  # Map over groups of sites to download data   
   tar_target(
     p1_wqp_data_aoi,
-    fetch_wqp_data(p1_site_ids_grouped, p1_char_names, 
-                   query_site_limit = 500, wqp_args = wqp_args)
+    fetch_wqp_data(p1_site_ids_grouped, p1_char_names, wqp_args = wqp_args),
+    pattern = map(p1_site_ids_grouped)
   )
 
 )

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -87,11 +87,19 @@ p1_targets_list <- list(
     p1_wqp_inventory_aoi,
     subset_inventory(p1_wqp_inventory, p1_AOI_sf, buffer_dist_m = 100)
   ),
+  
+  # Pull site id's from the WQP inventory
+  tar_target(
+    p1_site_ids,
+    p1_wqp_inventory_aoi %>%
+      pull(MonitoringLocationIdentifier) %>%
+      unique()
+  ),
 
   # Download data using output of WQP inventory  
   tar_target(
     p1_wqp_data_aoi,
-    fetch_wqp_data(p1_wqp_inventory_aoi, p1_char_names, 
+    fetch_wqp_data(p1_site_ids, p1_char_names, 
                    query_site_limit = 500, wqp_args = wqp_args)
   )
 

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -2,6 +2,7 @@
 source("1_fetch/src/check_characteristics.R")
 source("1_fetch/src/create_grids.R")
 source("1_fetch/src/get_wqp_inventory.R")
+source("1_fetch/src/fetch_wqp_data.R")
 
 p1_targets_list <- list(
   
@@ -85,6 +86,13 @@ p1_targets_list <- list(
   tar_target(
     p1_wqp_inventory_aoi,
     subset_inventory(p1_wqp_inventory, p1_AOI_sf, buffer_dist_m = 100)
+  ),
+
+  # Download data using output of WQP inventory  
+  tar_target(
+    p1_wqp_data_aoi,
+    fetch_wqp_data(p1_wqp_inventory_aoi, p1_char_names, 
+                   query_site_limit = 500, wqp_args = wqp_args)
   )
 
 )

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -95,11 +95,17 @@ p1_targets_list <- list(
       pull(MonitoringLocationIdentifier) %>%
       unique()
   ),
+  
+  # Group the sites into reasonably sized chunks for downloading data 
+  tar_target(
+    p1_site_ids_grouped,
+    add_download_groups(p1_site_ids, max_sites_allowed = 500)
+  ),
 
   # Download data using output of WQP inventory  
   tar_target(
     p1_wqp_data_aoi,
-    fetch_wqp_data(p1_site_ids, p1_char_names, 
+    fetch_wqp_data(p1_site_ids_grouped, p1_char_names, 
                    query_site_limit = 500, wqp_args = wqp_args)
   )
 

--- a/1_fetch/src/fetch_wqp_data.R
+++ b/1_fetch/src/fetch_wqp_data.R
@@ -28,10 +28,9 @@ add_download_groups <- function(siteids, max_sites_allowed = 500) {
 #' 
 #' @description Function to pull WQP data given a vector of site ids
 #'  
-#' @param siteids vector of character strings containing site identifiers
-#' @param query_site_limit integer; chunk up the WQP data pulls by setting 
-#' the maximum number of sites to include in any single data pull. Defaults
-#' to 500.
+#' @param siteids_grouped vector of character strings containing site identifiers
+#' @param characteristics vector of character strings indicating which WQP
+#' CharacteristicName to query
 #' @param min_results integer indicating the minumum number of records a site
 #' should contain to include that site in the data pull, defaults to 1.
 #' @param min_date character string indicating the earliest requested activity 
@@ -43,44 +42,20 @@ add_download_groups <- function(siteids, max_sites_allowed = 500) {
 #' @return returns a data frame containing data downloaded from the Water Quality Portal, 
 #' where each row represents a unique data record. 
 #' 
-fetch_wqp_data <- function(siteids, characteristics, query_site_limit = 500, 
+fetch_wqp_data <- function(siteids_grouped, characteristics,
                            min_results = 1, min_date = "", wqp_args = NULL){
   
-  n_total_sites <- length(siteids) 
+  message(sprintf("Retrieving WQP data for sites %s:%s",
+                  min(siteids_grouped$site_n), max(siteids_grouped$site_n)))
   
-  # Break up sites into multiple WQP calls to avoid timeout issues 
-  start_time <- Sys.time()
-  sites_chunk <- ceiling(n_total_sites/query_site_limit)
-
-  # Pull data for each chunk
-  wqp_data_ls <- list()
+  # Define arguments for readWQPdata
+  wqp_args_all <- c(wqp_args, list(siteid = siteids_grouped$site_id,
+                                   characteristicName = c(characteristics),
+                                   minresults = min_results, 
+                                   startDateLo = min_date))
   
-  for(i in seq_len(sites_chunk)){
-    start_chk <- (i-1)*query_site_limit + 1
-    end_chk <- ifelse(i == sites_chunk, n_total_sites, i*query_site_limit)
-
-    message(sprintf("Retrieving WQP data for sites %s:%s out of %s total sites",
-                    start_chk, end_chk, n_total_sites))
-    
-    # define arguments for readWQPdata
-    wqp_args_all <- c(wqp_args, list(siteid = siteids[start_chk:end_chk],
-                                 characteristicName = c(characteristics),
-                                 minresults = min_results, 
-                                 startDateLo = min_date))
-    # pull data
-    site_data <- dataRetrieval::readWQPdata(wqp_args_all)
-    wqp_data_ls[[i]] <- site_data
-  }
-  
-  # Return data frame containing all of the downloaded data
-  wqp_data <- bind_rows(wqp_data_ls)
-  
-  # Print messages that indicate how the download went
-  end_time <- Sys.time()
-  elapsed_time <- round(as.numeric(difftime(end_time, start_time, units = "secs")), 1)
-
-  message(sprintf("Retrieved %s rows of data in %s seconds", 
-                  length(wqp_data$ResultMeasureValue), elapsed_time))
+  # Pull data
+  wqp_data <- dataRetrieval::readWQPdata(wqp_args_all)
   
   return(wqp_data)
 }

--- a/1_fetch/src/fetch_wqp_data.R
+++ b/1_fetch/src/fetch_wqp_data.R
@@ -1,3 +1,29 @@
+#' Group sites for downloading data without hitting the WQP cap
+#' 
+#' @description This function returns a data frame with a single column used
+#' to group the sites into reasonably sized chunks for downloading data.
+#' 
+#' @param siteids vector of character strings containing site identifiers
+#' @param max_sites_allowed integer indicating the maximum number
+#' of sites allowed in each download group. Defaults to 500.
+#' 
+#' @return returns a data frame with columns site id, site number, and an 
+#' additional column called `download_grp` which is made up of unique groups 
+#' to `group_by()` and then `tar_group()` for downloading.
+#' 
+add_download_groups <- function(siteids, max_sites_allowed = 500) {
+  
+  siteids_df <- tibble(site_id = siteids) %>%
+    mutate(site_n = row_number()) %>%
+    # Add a column indicating which chunk a site belongs to; the number of rows
+    # in each chunk should not exceed `max_sites_allowed`
+    mutate(download_grp = ((site_n -1) %/% max_sites_allowed) + 1)
+  
+  return(siteids_df)
+
+}
+
+
 #' Download data from the Water Quality Portal
 #' 
 #' @description Function to pull WQP data given a vector of site ids
@@ -14,7 +40,7 @@
 #' defaults to NULL. See https://www.waterqualitydata.us/webservices_documentation 
 #' for more information.  
 #' 
-#' @value returns a data frame containing data downloaded from the Water Quality Portal, 
+#' @return returns a data frame containing data downloaded from the Water Quality Portal, 
 #' where each row represents a unique data record. 
 #' 
 fetch_wqp_data <- function(siteids, characteristics, query_site_limit = 500, 

--- a/1_fetch/src/fetch_wqp_data.R
+++ b/1_fetch/src/fetch_wqp_data.R
@@ -1,9 +1,6 @@
-fetch_wqp_data <- function(wqp_inventory, characteristics, query_site_limit = 500, 
+fetch_wqp_data <- function(siteids, characteristics, query_site_limit = 500, 
                            min_results = 1, min_date = "", wqp_args = NULL){
   
-  siteids <- wqp_inventory %>%
-    pull(MonitoringLocationIdentifier) %>%
-    unique()
   n_total_sites <- length(siteids) 
   
   # Break up sites into multiple WQP calls to avoid timeout issues 

--- a/1_fetch/src/fetch_wqp_data.R
+++ b/1_fetch/src/fetch_wqp_data.R
@@ -1,3 +1,22 @@
+#' Download data from the Water Quality Portal
+#' 
+#' @description Function to pull WQP data given a vector of site ids
+#'  
+#' @param siteids vector of character strings containing site identifiers
+#' @param query_site_limit integer; chunk up the WQP data pulls by setting 
+#' the maximum number of sites to include in any single data pull. Defaults
+#' to 500.
+#' @param min_results integer indicating the minumum number of records a site
+#' should contain to include that site in the data pull, defaults to 1.
+#' @param min_date character string indicating the earliest requested activity 
+#' start date, defaults to "", which returns all available records. 
+#' @param wqp_args list containing additional arguments to pass to whatWQPdata(),
+#' defaults to NULL. See https://www.waterqualitydata.us/webservices_documentation 
+#' for more information.  
+#' 
+#' @value returns a data frame containing data downloaded from the Water Quality Portal, 
+#' where each row represents a unique data record. 
+#' 
 fetch_wqp_data <- function(siteids, characteristics, query_site_limit = 500, 
                            min_results = 1, min_date = "", wqp_args = NULL){
   

--- a/1_fetch/src/fetch_wqp_data.R
+++ b/1_fetch/src/fetch_wqp_data.R
@@ -1,0 +1,45 @@
+fetch_wqp_data <- function(wqp_inventory, characteristics, query_site_limit = 500, 
+                           min_results = 1, min_date = "", wqp_args = NULL){
+  
+  siteids <- wqp_inventory %>%
+    pull(MonitoringLocationIdentifier) %>%
+    unique()
+  n_total_sites <- length(siteids) 
+  
+  # Break up sites into multiple WQP calls to avoid timeout issues 
+  start_time <- Sys.time()
+  sites_chunk <- ceiling(n_total_sites/query_site_limit)
+
+  # Pull data for each chunk
+  wqp_data_ls <- list()
+  
+  for(i in seq_len(sites_chunk)){
+    start_chk <- (i-1)*query_site_limit + 1
+    end_chk <- ifelse(i == sites_chunk, n_total_sites, i*query_site_limit)
+
+    message(sprintf("Retrieving WQP data for sites %s:%s out of %s total sites",
+                    start_chk, end_chk, n_total_sites))
+    
+    # define arguments for readWQPdata
+    wqp_args_all <- c(wqp_args, list(siteid = siteids[start_chk:end_chk],
+                                 characteristicName = c(characteristics),
+                                 minresults = min_results, 
+                                 startDateLo = min_date))
+    # pull data
+    site_data <- dataRetrieval::readWQPdata(wqp_args_all)
+    wqp_data_ls[[i]] <- site_data
+  }
+  
+  # Return data frame containing all of the downloaded data
+  wqp_data <- bind_rows(wqp_data_ls)
+  
+  # Print messages that indicate how the download went
+  end_time <- Sys.time()
+  elapsed_time <- round(as.numeric(difftime(end_time, start_time, units = "secs")), 1)
+
+  message(sprintf("Retrieved %s rows of data in %s seconds", 
+                  length(wqp_data$ResultMeasureValue), elapsed_time))
+  
+  return(wqp_data)
+}
+


### PR DESCRIPTION
This PR downloads data from the WQP based on sites returned in `p1_wqp_inventory_aoi`. The code currently chunks up the WQP data pulls based on a maximum number of unique sites set by the user. I experimented a bit with also chunking queries by total results returned. I didn't notice much improvement in download speed, for example, so opted to stick with chunks based on sites. However, perhaps this approach would become more fragile as the AOI is expanded and/or if the number of characteristics is much larger. I'd be curious to hear any other thoughts you have on these 'chunking' decisions.

Here's a preview of our pipeline:

![Rplot](https://user-images.githubusercontent.com/8785034/168116582-6970a9af-a13d-4bc7-be76-2831eb33a453.png)

And here is what the output of `p1_wqp_data_aoi` looks like for me:
```
> tar_load(p1_wqp_data_aoi)
> dim(p1_wqp_data_aoi)
[1] 39071    65
> length(unique(p1_wqp_data_aoi$MonitoringLocationIdentifier))
[1] 1111
>
```


Closes #28.