### PR TITLE
Explicitly load sf package when building WQP inventory target

### DIFF
--- a/1_fetch/src/get_wqp_inventory.R
+++ b/1_fetch/src/get_wqp_inventory.R
@@ -15,6 +15,9 @@
 #' @example inventory_wqp(aoi_bbox, "Conductivity", wqp_args = list(siteType = "Stream"))
 #' @example inventory_wqp(aoi_bbox, "Temperature", wqp_args = list(siteType = "Lake, Reservoir, Impoundment"))
 #' 
+#' explicitly load and attach sf package to handle geometry data in `grid`
+library(sf)
+
 inventory_wqp <- function(grid, char_names, wqp_args = NULL){
   
   # Get bounding box for the grid polygon


### PR DESCRIPTION
This PR adds an explicit `library(sf)` call to `1_fetch/src/get_wqp_inventory.R`. Without attaching {sf}, issues with {sf} and {tibble} result in an error when trying to run `inventory_wqp` in the context of re-building the targets pipeline.

Closes #39 