### PR TITLE
Include resultCount in grouped sites

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -98,7 +98,7 @@ p1_targets_list <- list(
   
   # Pull site id's and total number of records for each site from the WQP inventory
   tar_target(
-    p1_site_ids,
+    p1_site_counts,
     p1_wqp_inventory_aoi %>%
       group_by(MonitoringLocationIdentifier) %>%
       summarize(results_count = sum(resultCount, na.rm = TRUE))
@@ -106,8 +106,8 @@ p1_targets_list <- list(
   
   # Group the sites into reasonably sized chunks for downloading data 
   tar_target(
-    p1_site_ids_grouped,
-    add_download_groups(p1_site_ids, max_sites_allowed = 500) %>%
+    p1_site_counts_grouped,
+    add_download_groups(p1_site_counts, max_sites_allowed = 500) %>%
       group_by(download_grp) %>%
       tar_group(),
     iteration = "group"
@@ -116,8 +116,8 @@ p1_targets_list <- list(
   # Map over groups of sites to download data   
   tar_target(
     p1_wqp_data_aoi,
-    fetch_wqp_data(p1_site_ids_grouped, p1_char_names, wqp_args = wqp_args),
-    pattern = map(p1_site_ids_grouped)
+    fetch_wqp_data(p1_site_counts_grouped, p1_char_names, wqp_args = wqp_args),
+    pattern = map(p1_site_counts_grouped)
   ),
   
   # Summarize the data downloaded from the WQP

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -96,12 +96,12 @@ p1_targets_list <- list(
     format = "file"
   ),
   
-  # Pull site id's from the WQP inventory
+  # Pull site id's and total number of records for each site from the WQP inventory
   tar_target(
     p1_site_ids,
     p1_wqp_inventory_aoi %>%
-      pull(MonitoringLocationIdentifier) %>%
-      unique()
+      group_by(MonitoringLocationIdentifier) %>%
+      summarize(results_count = sum(resultCount, na.rm = TRUE))
   ),
   
   # Group the sites into reasonably sized chunks for downloading data 

--- a/1_fetch/log/summary_wqp_data.csv
+++ b/1_fetch/log/summary_wqp_data.csv
@@ -1,5 +1,5 @@
 CharacteristicName,sites_count,results_count
 Conductivity,4,7
-Specific conductance,496,11490
+Specific conductance,496,11488
 "Specific Conductance, Calculated/Measured Ratio",2,48
 "Temperature, water",506,8805

--- a/1_fetch/log/summary_wqp_inventory.csv
+++ b/1_fetch/log/summary_wqp_inventory.csv
@@ -1,5 +1,5 @@
 CharacteristicName,sites_count,results_count
 Conductivity,4,7
-Specific conductance,496,11490
+Specific conductance,496,11488
 "Specific Conductance, Calculated/Measured Ratio",2,48
 "Temperature, water",506,8805

--- a/1_fetch/src/fetch_wqp_data.R
+++ b/1_fetch/src/fetch_wqp_data.R
@@ -3,23 +3,25 @@
 #' @description This function returns a data frame with a single column used
 #' to group the sites into reasonably sized chunks for downloading data.
 #' 
-#' @param siteids vector of character strings containing site identifiers
-#' @param max_sites_allowed integer indicating the maximum number
-#' of sites allowed in each download group. Defaults to 500.
+#' @param siteids_df data frame containing the site identifiers and total number of
+#' records available for each site. Must contain column `MonitoringLocationIdentifier`.
+#' @param max_sites_allowed integer indicating the maximum number of sites allowed
+#' in each download group. Defaults to 500.
 #' 
-#' @return returns a data frame with columns site id, site number, and an 
-#' additional column called `download_grp` which is made up of unique groups 
-#' to `group_by()` and then `tar_group()` for downloading.
+#' @return returns a data frame with columns site id, the total number of records,
+#' site number, and an additional column called `download_grp` which is made up of
+#' unique groups that enable use of `group_by()` and then `tar_group()` for downloading.
 #' 
-add_download_groups <- function(siteids, max_sites_allowed = 500) {
+add_download_groups <- function(siteids_df, max_sites_allowed = 500) {
   
-  siteids_df <- tibble(site_id = siteids) %>%
+  siteids_grouped <- siteids_df %>%
+    rename(site_id = MonitoringLocationIdentifier) %>% 
     mutate(site_n = row_number()) %>%
     # Add a column indicating which chunk a site belongs to; the number of rows
     # in each chunk should not exceed `max_sites_allowed`
     mutate(download_grp = ((site_n -1) %/% max_sites_allowed) + 1)
   
-  return(siteids_df)
+  return(siteids_grouped)
 
 }
 

--- a/1_fetch/src/fetch_wqp_data.R
+++ b/1_fetch/src/fetch_wqp_data.R
@@ -3,25 +3,26 @@
 #' @description This function returns a data frame with a single column used
 #' to group the sites into reasonably sized chunks for downloading data.
 #' 
-#' @param siteids_df data frame containing the site identifiers and total number of
-#' records available for each site. Must contain column `MonitoringLocationIdentifier`.
+#' @param sitecounts_df data frame containing the site identifiers and total number of
+#' records available for each site. Must contain columns `MonitoringLocationIdentifier`.
 #' @param max_sites_allowed integer indicating the maximum number of sites allowed
 #' in each download group. Defaults to 500.
 #' 
 #' @return returns a data frame with columns site id, the total number of records,
-#' site number, and an additional column called `download_grp` which is made up of
-#' unique groups that enable use of `group_by()` and then `tar_group()` for downloading.
+#' (retains the column from `sitecounts_df`), site number, and an additional column 
+#' called `download_grp` which is made up of unique groups that enable use of 
+#' `group_by()` and then `tar_group()` for downloading.
 #' 
-add_download_groups <- function(siteids_df, max_sites_allowed = 500) {
+add_download_groups <- function(sitecounts_df, max_sites_allowed = 500) {
   
-  siteids_grouped <- siteids_df %>%
+  sitecounts_grouped <- sitecounts_df %>%
     rename(site_id = MonitoringLocationIdentifier) %>% 
     mutate(site_n = row_number()) %>%
     # Add a column indicating which chunk a site belongs to; the number of rows
     # in each chunk should not exceed `max_sites_allowed`
     mutate(download_grp = ((site_n -1) %/% max_sites_allowed) + 1)
   
-  return(siteids_grouped)
+  return(sitecounts_grouped)
 
 }
 

--- a/1_fetch/src/get_wqp_inventory.R
+++ b/1_fetch/src/get_wqp_inventory.R
@@ -27,7 +27,7 @@ inventory_wqp <- function(grid, char_names, wqp_args = NULL){
   char_names <- as.character(unlist(char_names))
   
   # Print time-specific message so user can see progress
-  message(sprintf('Retrieving whatWQPdata for grid %s...', grid$id))
+  message(sprintf('Inventorying WQP data for grid %s', grid$id))
 
   # Inventory available WQP data
   wqp_inventory <- lapply(char_names,function(x){


### PR DESCRIPTION
This PR makes relatively minor modifications to `p1_site_ids` so that the total number of records gets passed to `p1_site_ids_grouped` and ultimately, `fetch_wqp_data()`, in addition to just the site ids. Adding the total number of records to the data frame that gets passed to `fetch_wqp_data()` is meant to avoid an edge case where the upstream inventory values of `resultCount` have changed but the site ids remain the same, and so no new data gets pulled as a result.

In addition, this PR includes a minor edit to the inventory status message that prints to the console when building `p1_wqp_inventory`.

Closes #44
Closes #45