### PR TITLE
Expand and simplify big (CONUS) grid

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -54,22 +54,22 @@ p1_targets_list <- list(
   
   # Create a big grid of boxes to set up chunked data queries
   tar_target(
-    p1_conus_grid,
-    create_conus_grid(cellsize = c(1,1))
+    p1_nationwide_grid,
+    create_nationwide_grid(cellsize = c(1,1))
   ),
   
   # Use spatial subsetting to find boxes that overlap the area of interest
   # (i.e., are within dist_m of p1_AOI_sf). These boxes will be used to
   # query the WQP.
   tar_target(
-    p1_conus_grid_aoi,
-    subset_grids_to_aoi(p1_conus_grid, p1_AOI_sf, dist_m = 5000)
+    p1_nationwide_grid_aoi,
+    subset_grids_to_aoi(p1_nationwide_grid, p1_AOI_sf, dist_m = 5000)
   ),
   
   # Inventory data available from the WQP within each of the boxes that overlap
   # the area of interest. To prevent timeout issues that result from large data 
   # requests, use {targets} dynamic branching capabilities to map the function 
-  # inventory_wqp() over each grid within p1_conus_grid_aoi. {targets} will 
+  # inventory_wqp() over each grid within p1_nationwide_grid_aoi. {targets} will 
   # then combine all of the grid-scale inventories into one table.
   tar_target(
     p1_wqp_inventory,
@@ -77,10 +77,10 @@ p1_targets_list <- list(
     # also pass additional arguments to WQP, e.g. sampleMedia or siteType, using 
     # wqp_args. Below, wqp_args is defined in _targets.R. See documentation
     # in 1_fetch/src/get_wqp_inventory.R for further details.
-    inventory_wqp(grid = p1_conus_grid_aoi,
+    inventory_wqp(grid = p1_nationwide_grid_aoi,
                   char_names = p1_char_names,
                   wqp_args = wqp_args),
-    pattern = map(p1_conus_grid_aoi)
+    pattern = map(p1_nationwide_grid_aoi)
   ),
   
   # Subset the WQP inventory to only retain sites within the area of interest

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -52,24 +52,26 @@ p1_targets_list <- list(
       sf::st_cast("POLYGON")
   ),
   
-  # Create a big grid of boxes to set up chunked data queries
+  # Create a big grid of boxes to set up chunked data queries.
+  # The resulting grid, which covers the globe, allows for queries
+  # outside of CONUS, including AK, HI, and US territories. 
   tar_target(
-    p1_nationwide_grid,
-    create_nationwide_grid(cellsize = c(1,1))
+    p1_global_grid,
+    create_global_grid()
   ),
   
   # Use spatial subsetting to find boxes that overlap the area of interest
   # (i.e., are within dist_m of p1_AOI_sf). These boxes will be used to
   # query the WQP.
   tar_target(
-    p1_nationwide_grid_aoi,
-    subset_grids_to_aoi(p1_nationwide_grid, p1_AOI_sf, dist_m = 5000)
+    p1_global_grid_aoi,
+    subset_grids_to_aoi(p1_global_grid, p1_AOI_sf, dist_m = 5000)
   ),
   
   # Inventory data available from the WQP within each of the boxes that overlap
   # the area of interest. To prevent timeout issues that result from large data 
   # requests, use {targets} dynamic branching capabilities to map the function 
-  # inventory_wqp() over each grid within p1_nationwide_grid_aoi. {targets} will 
+  # inventory_wqp() over each grid within p1_global_grid_aoi. {targets} will 
   # then combine all of the grid-scale inventories into one table.
   tar_target(
     p1_wqp_inventory,
@@ -77,10 +79,10 @@ p1_targets_list <- list(
     # also pass additional arguments to WQP, e.g. sampleMedia or siteType, using 
     # wqp_args. Below, wqp_args is defined in _targets.R. See documentation
     # in 1_fetch/src/get_wqp_inventory.R for further details.
-    inventory_wqp(grid = p1_nationwide_grid_aoi,
+    inventory_wqp(grid = p1_global_grid_aoi,
                   char_names = p1_char_names,
                   wqp_args = wqp_args),
-    pattern = map(p1_nationwide_grid_aoi)
+    pattern = map(p1_global_grid_aoi)
   ),
   
   # Subset the WQP inventory to only retain sites within the area of interest

--- a/1_fetch/src/create_grids.R
+++ b/1_fetch/src/create_grids.R
@@ -1,35 +1,50 @@
-#' Create CONUS grid
-#' 
+#' Create a nationwide grid including AK/HI and territories
+#'  
 #' @description Function to create a big grid of boxes to use for chunked
 #' data queries
 #' 
 #' @param cellsize the target cell size of each box in map units (here, degrees);
 #' takes two values indicating the size in the x direction and the size in the 
-#' y direction, see ??sf::st_make_grid for further details.
+#' y direction. Defaults to 2 degree cell size. See ??sf::st_make_grid for 
+#' further details.
 #' @param year integer; year of the state polygon data download (defaults to 2020); 
 #' see ??tigris::states for further details.
 #' @param progress_bar logical; indicates whether a progress bar showing the status
 #' of the state polygon build should be returned (defaults to FALSE)
 #' 
 #' @value returns an sf polygon object containing the geometries and an attribute 
-#' id for each box within the CONUS grid.
+#' id for each box within the nationwide grid.
 #' 
-#' @example create_conus_grid(cellsize = c(1,1))
+#' @example create_nationwide_grid(cellsize = c(2,2))
 #' 
 
-create_conus_grid <- function(cellsize, year = 2020, progress_bar = FALSE){
+create_nationwide_grid <- function(cellsize = c(2,2), year = 2020, progress_bar = FALSE){
  
-  conus_grid <- tigris::states(class = "sf", year = year, progress_bar = progress_bar) %>%
-    # filter state polygons to CONUS extent
-    filter(REGION != "9", 
-           !STUSPS %in% c("HI","AK")) %>%
-    # create square grid with cell sizes equal to 1 deg. x 1 deg.
-    sf::st_make_grid(cellsize = c(cellsize[1],cellsize[2]), square = TRUE) %>%
+  usa_sf <- tigris::states(class = "sf", year = year, progress_bar = progress_bar)
+  
+  # create square grid with cell sizes equal to `cellsize` passed in degrees.
+  usa_grid <- usa_sf %>%
+    sf::st_make_grid(cellsize = c(cellsize[1],cellsize[2]), square = TRUE, 
+                     # Start lower left of grid right at 180th meridian to avoid
+                     # issues with WQP query bboxes crossing from E longitudes to W
+                     # See https://github.com/USGS-R/dataRetrieval/issues/616
+                     offset = c(-180, sf::st_bbox(usa_sf)$ymin)) %>%
     # convert to sf object and add an "id" attribute
     sf::st_as_sf() %>%
     mutate(id = row.names(.))
   
-  return(conus_grid)
+  # Check that usa_grid produces a valid bounding box to pass to WQP. Check that
+  # the west-east coordinates don't cross 180. Note that this behavior could 
+  # result from picking a cellsize[1] that 180 is not evenly divisible by (like 7)
+  # because it results in a grid cell crossing the 180th meridian.
+  grid_xmaxes <- purrr::map(usa_grid$x, function(grid) st_bbox(grid)$xmax)
+  if(any(unlist(grid_xmaxes) > 180)) {
+    stop("Grid cells cross over 180 deg meridian and will cause WQP 
+    calls to fail. Change `cellsize[1]` so that 180 is divisible 
+    by it or make adjustments to `create_national_grid()`")
+  }
+  
+  return(usa_grid)
   
 }
 
@@ -50,7 +65,7 @@ create_conus_grid <- function(cellsize, year = 2020, progress_bar = FALSE){
 #' @value returns an sf polygon object containing the geometries for each box 
 #' within the holistic grid that overlaps the buffered area of interest.
 #' 
-#' @example subset_grids_to_aoi(grid = p1_conus_grid, dist_m = 5000)
+#' @example subset_grids_to_aoi(grid = p1_nationwide_grid, dist_m = 5000)
 #' 
 
 subset_grids_to_aoi <- function(grid, aoi_poly, dist_m){

--- a/1_fetch/src/create_grids.R
+++ b/1_fetch/src/create_grids.R
@@ -1,4 +1,4 @@
-#' Create a nationwide grid including AK/HI and territories
+#' Create a big grid that covers the globe
 #'  
 #' @description Function to create a big grid of boxes to use for chunked
 #' data queries
@@ -7,44 +7,42 @@
 #' takes two values indicating the size in the x direction and the size in the 
 #' y direction. Defaults to 2 degree cell size. See ??sf::st_make_grid for 
 #' further details.
-#' @param year integer; year of the state polygon data download (defaults to 2020); 
-#' see ??tigris::states for further details.
-#' @param progress_bar logical; indicates whether a progress bar showing the status
-#' of the state polygon build should be returned (defaults to FALSE)
 #' 
 #' @value returns an sf polygon object containing the geometries and an attribute 
-#' id for each box within the nationwide grid.
+#' id for each box within the global grid.
 #' 
-#' @example create_nationwide_grid(cellsize = c(2,2))
+#' @example create_global_grid(cellsize = c(1,1))
 #' 
 
-create_nationwide_grid <- function(cellsize = c(2,2), year = 2020, progress_bar = FALSE){
+create_global_grid <- function(cellsize = c(2,2)){
  
-  usa_sf <- tigris::states(class = "sf", year = year, progress_bar = progress_bar)
+  global_box <- sf::st_bbox(c(xmin = -180, xmax = 180,
+                              ymax = 90, ymin = -90), 
+                            crs = sf::st_crs(4326))
   
   # create square grid with cell sizes equal to `cellsize` passed in degrees.
-  usa_grid <- usa_sf %>%
+  global_grid <- global_box %>%
     sf::st_make_grid(cellsize = c(cellsize[1],cellsize[2]), square = TRUE, 
                      # Start lower left of grid right at 180th meridian to avoid
                      # issues with WQP query bboxes crossing from E longitudes to W
                      # See https://github.com/USGS-R/dataRetrieval/issues/616
-                     offset = c(-180, sf::st_bbox(usa_sf)$ymin)) %>%
+                     offset = c(-180, sf::st_bbox(global_box)$ymin)) %>%
     # convert to sf object and add an "id" attribute
     sf::st_as_sf() %>%
     mutate(id = row.names(.))
   
-  # Check that usa_grid produces a valid bounding box to pass to WQP. Check that
+  # Check that global_grid produces a valid bounding box to pass to WQP. Check that
   # the west-east coordinates don't cross 180. Note that this behavior could 
   # result from picking a cellsize[1] that 180 is not evenly divisible by (like 7)
   # because it results in a grid cell crossing the 180th meridian.
-  grid_xmaxes <- purrr::map(usa_grid$x, function(grid) st_bbox(grid)$xmax)
+  grid_xmaxes <- purrr::map(global_grid$x, function(grid) st_bbox(grid)$xmax)
   if(any(unlist(grid_xmaxes) > 180)) {
     stop("Grid cells cross over 180 deg meridian and will cause WQP 
     calls to fail. Change `cellsize[1]` so that 180 is divisible 
-    by it or make adjustments to `create_national_grid()`")
+    by it or make adjustments to `create_global_grid()`")
   }
   
-  return(usa_grid)
+  return(global_grid)
   
 }
 
@@ -65,7 +63,7 @@ create_nationwide_grid <- function(cellsize = c(2,2), year = 2020, progress_bar 
 #' @value returns an sf polygon object containing the geometries for each box 
 #' within the holistic grid that overlaps the buffered area of interest.
 #' 
-#' @example subset_grids_to_aoi(grid = p1_nationwide_grid, dist_m = 5000)
+#' @example subset_grids_to_aoi(grid = p1_global_grid, dist_m = 5000)
 #' 
 
 subset_grids_to_aoi <- function(grid, aoi_poly, dist_m){


### PR DESCRIPTION
This pipeline uses a big grid of boxes to set up cells for querying WQP. Initially this target (`p1_conus_grid`) only included the continental United States and so the pipeline couldn't be used in other places where WQP data exists, including AK, HI, and US territories. 

This PR borrows from @lindsayplatt's national chlorophyll pull to expand the grid to cover a broader extent (kudos to Lindsay for troubleshooting issues when the cells cross the 180th meridian!). In addition, this PR removes the {tigris} dependency by defining a global bounding box. The user cannot change this spatial extent, but can edit the optional `cellsize` argument to change the cell sizes in the resulting grid. 

The code here uses 2 degree cell sizes by default, which results in 16,200 cells that are later filtered to those that overlap the area of interest:
```
> tar_load(p1_global_grid)
> dim(p1_global_grid)
[1] 16200     2
>
```

Closes #42