### PR TITLE
Coerce all columns to character when building `p1_wqp_data_aoi`

### DIFF
--- a/1_fetch/src/fetch_wqp_data.R
+++ b/1_fetch/src/fetch_wqp_data.R
@@ -29,9 +29,11 @@ add_download_groups <- function(sitecounts_df, max_sites_allowed = 500) {
 
 #' Download data from the Water Quality Portal
 #' 
-#' @description Function to pull WQP data given a vector of site ids
+#' @description Function to pull WQP data given a dataset of site ids
 #'  
-#' @param siteids_grouped vector of character strings containing site identifiers
+#' @param site_counts_grouped data frame containing site identifiers, the 
+#' total number of records, site numbers, and a download group assigned
+#' for each site. Must contain columns `site_id` and `site_n`.
 #' @param characteristics vector of character strings indicating which WQP
 #' CharacteristicName to query
 #' @param wqp_args list containing additional arguments to pass to whatWQPdata(),
@@ -41,18 +43,26 @@ add_download_groups <- function(sitecounts_df, max_sites_allowed = 500) {
 #' @return returns a data frame containing data downloaded from the Water Quality Portal, 
 #' where each row represents a unique data record. 
 #' 
-fetch_wqp_data <- function(siteids_grouped, characteristics, wqp_args = NULL){
+fetch_wqp_data <- function(site_counts_grouped, characteristics, wqp_args = NULL){
   
   message(sprintf("Retrieving WQP data for sites %s:%s",
-                  min(siteids_grouped$site_n), max(siteids_grouped$site_n)))
+                  min(site_counts_grouped$site_n), 
+                  max(site_counts_grouped$site_n)))
   
   # Define arguments for readWQPdata
-  wqp_args_all <- c(wqp_args, list(siteid = siteids_grouped$site_id,
+  wqp_args_all <- c(wqp_args, list(siteid = site_counts_grouped$site_id,
                                    characteristicName = c(characteristics)))
   
   # Pull data
   wqp_data <- dataRetrieval::readWQPdata(wqp_args_all)
   
-  return(wqp_data)
+  # Some records return character strings when we expect numeric values, 
+  # e.g. when "*Non-detect" appears in the "ResultMeasureValue" field. 
+  # For now, consider all columns to be character so that individual data
+  # frames returned from fetch_wqp_data can be joined together. 
+  wqp_data_out <- wqp_data %>%
+    mutate(across(everything(), as.character))
+  
+  return(wqp_data_out)
 }
 


### PR DESCRIPTION
In data downloaded from WQP, we sometimes see character strings entered into columns that we expect to be numeric (see #47 for examples and details). This can cause our pipeline to fail, because the individual branches in `p1_wqp_data_aoi` cannot be joined into a single data frame. The code changes here coerce all columns to class `character` when building `p1_wqp_data_aoi`. I propose closing #47 with this PR and opening a new issue for a downstream harmonization step that handles column classes for select columns (e.g. `ResultMeasureValue`, others).

Finally, I haven't committed any changes to our inputs in _targets.R, but if you want to test this code change, I'd recommend replacing the inputs in _targets.R with the inputs that Jordan used for stress-testing in #47:

``` r
# Specify coordinates that define the spatial area of interest
# lat/lon are referenced to WGS84
coords_lon <- c(-90.333, -87.8, -89)
coords_lat <- c(42.547, 45.029, 35.880)

# Specify arguments to WQP queries
# see https://www.waterqualitydata.us/webservices_documentation for more information 
wqp_args <- list(sampleMedia = c("Water","water"),
                 siteType = "Lake, Reservoir, Impoundment",
                 # return sites with at least one data record
                 minresults = 1, 
                 startDateLo = start_date,
                 startDateHi = end_date)
```

