### PR TITLE
Use default buffer distance of 0

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -88,7 +88,7 @@ p1_targets_list <- list(
   # Subset the WQP inventory to only retain sites within the area of interest
   tar_target(
     p1_wqp_inventory_aoi,
-    subset_inventory(p1_wqp_inventory, p1_AOI_sf, buffer_dist_m = 100)
+    subset_inventory(p1_wqp_inventory, p1_AOI_sf)
   ),
   
   # Summarize the data that would come back from the WQP

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -47,7 +47,7 @@ p1_targets_list <- list(
   # Create a spatial (sf) object representing the area of interest
   tar_target(
     p1_AOI_sf,
-    sf::st_as_sf(p1_AOI,coords=c("lon","lat"),crs=4326) %>%
+    sf::st_as_sf(p1_AOI, coords = c("lon","lat"), crs = 4326) %>%
       summarize(geometry = st_combine(geometry)) %>%
       sf::st_cast("POLYGON")
   ),
@@ -65,7 +65,7 @@ p1_targets_list <- list(
   # query the WQP.
   tar_target(
     p1_global_grid_aoi,
-    subset_grids_to_aoi(p1_global_grid, p1_AOI_sf, dist_m = 5000)
+    subset_grids_to_aoi(p1_global_grid, p1_AOI_sf)
   ),
   
   # Inventory data available from the WQP within each of the boxes that overlap

--- a/1_fetch/log/summary_wqp_data.csv
+++ b/1_fetch/log/summary_wqp_data.csv
@@ -1,5 +1,5 @@
 CharacteristicName,sites_count,results_count
 Conductivity,4,7
-Specific conductance,496,11488
+Specific conductance,494,11438
 "Specific Conductance, Calculated/Measured Ratio",2,48
-"Temperature, water",506,8805
+"Temperature, water",504,8773

--- a/1_fetch/log/summary_wqp_inventory.csv
+++ b/1_fetch/log/summary_wqp_inventory.csv
@@ -1,5 +1,5 @@
 CharacteristicName,sites_count,results_count
 Conductivity,4,7
-Specific conductance,496,11488
+Specific conductance,494,11438
 "Specific Conductance, Calculated/Measured Ratio",2,48
-"Temperature, water",506,8805
+"Temperature, water",504,8773

--- a/1_fetch/src/create_grids.R
+++ b/1_fetch/src/create_grids.R
@@ -56,7 +56,7 @@ create_global_grid <- function(cellsize = c(2,2)){
 #' 
 #' @param grid sf polygon object containing the geometries and an attribute 
 #' id for each box within the grid.
-#' @param aoi_poly sf polygon object representing the area of interest
+#' @param aoi_sf sf polygon object representing the area of interest
 #' @param buffer_dist_m integer; grid geometries will be returned if distances 
 #' between the grid polygons and the aoi polygon are smaller or equal to this value.
 #' Defaults to 0 meters, although users may adjust the distance.
@@ -64,16 +64,18 @@ create_global_grid <- function(cellsize = c(2,2)){
 #' @value returns an sf polygon object containing the geometries for each box 
 #' within the holistic grid that overlaps the buffered area of interest.
 #' 
-#' @example subset_grids_to_aoi(grid = p1_global_grid, dist_m = 5000)
+#' @example subset_grids_to_aoi(grid = p1_global_grid, 
+#'                              aoi_sf = p1_AOI_sf, 
+#'                              dist_m = 5000)
 #' 
 
-subset_grids_to_aoi <- function(grid, aoi_poly, buffer_dist_m = 0){
+subset_grids_to_aoi <- function(grid, aoi_sf, buffer_dist_m = 0){
 
   
   # Filter the big grid of boxes to only include those that overlap/are within
   # a given distance of the area of interest
   grid_subset_aoi <- grid %>%
-    sf::st_filter(y = sf::st_transform(aoi_poly, sf::st_crs(grid)),
+    sf::st_filter(y = sf::st_transform(aoi_sf, sf::st_crs(grid)),
                   .predicate = st_is_within_distance,
                   dist = units::set_units(buffer_dist_m, m))   
   

--- a/1_fetch/src/create_grids.R
+++ b/1_fetch/src/create_grids.R
@@ -57,8 +57,9 @@ create_global_grid <- function(cellsize = c(2,2)){
 #' @param grid sf polygon object containing the geometries and an attribute 
 #' id for each box within the grid.
 #' @param aoi_poly sf polygon object representing the area of interest
-#' @param dist_m integer; grid geometries will be returned if distances between
-#' the grid polygons and the aoi polygon are smaller or equal to this value.
+#' @param buffer_dist_m integer; grid geometries will be returned if distances 
+#' between the grid polygons and the aoi polygon are smaller or equal to this value.
+#' Defaults to 0 meters, although users may adjust the distance.
 #' 
 #' @value returns an sf polygon object containing the geometries for each box 
 #' within the holistic grid that overlaps the buffered area of interest.
@@ -66,14 +67,15 @@ create_global_grid <- function(cellsize = c(2,2)){
 #' @example subset_grids_to_aoi(grid = p1_global_grid, dist_m = 5000)
 #' 
 
-subset_grids_to_aoi <- function(grid, aoi_poly, dist_m){
+subset_grids_to_aoi <- function(grid, aoi_poly, buffer_dist_m = 0){
 
   
   # Filter the big grid of boxes to only include those that overlap/are within
   # a given distance of the area of interest
   grid_subset_aoi <- grid %>%
-    sf::st_filter(y = sf::st_transform(aoi_poly,sf::st_crs(grid)),
-                  .predicate = st_is_within_distance,dist=units::set_units(dist_m, m))   
+    sf::st_filter(y = sf::st_transform(aoi_poly, sf::st_crs(grid)),
+                  .predicate = st_is_within_distance,
+                  dist = units::set_units(buffer_dist_m, m))   
   
   return(grid_subset_aoi)
   

--- a/_targets.R
+++ b/_targets.R
@@ -2,7 +2,7 @@ library(targets)
 
 options(tidyverse.quiet = TRUE)
 tar_option_set(packages = c('tidyverse', 'lubridate', 'dataRetrieval', 
-                            'sf', 'tigris', 'xml2'))
+                            'sf', 'xml2', 'units'))
 
 source("1_fetch.R")
 


### PR DESCRIPTION
This PR implements default buffer distances of 0 m in two functions that carry out spatial subsetting, `subset_grids_to_aoi()` and `subset_inventory()`. For our targets that are built from these functions (`p1_global_grid_aoi` and `p1_wqp_inventory_aoi`) the default buffer distance is used. As Jordan suggests in #41, a user could still change these buffer distances if desired, but making this argument implicit simplifies our example and hopefully avoids any confusion as to what values should be entered for the distances. 

Note that this change results in 2 sites getting dropped from `p1_wqp_inventory_aoi` because they were within 100 m of the area of interest (the value formerly used as a buffer distance) but do not overlap the aoi, as implied by the default buffer distance of 0. 

![sites_dropped](https://user-images.githubusercontent.com/8785034/175651759-66e318a4-dccd-428a-b1e3-406bb87aae72.png)

So here is what the output summary looks like for me:

```r
> tar_load(p1_wqp_data_summary_csv)
> read_csv(p1_wqp_data_summary_csv, show_col_types = FALSE)
# A tibble: 4 x 3                                                                                                                                                                
  CharacteristicName                              sites_count results_count
  <chr>                                                 <dbl>         <dbl>
1 Conductivity                                              4             7
2 Specific conductance                                    494         11438
3 Specific Conductance, Calculated/Measured Ratio           2            48
4 Temperature, water                                      504          8773
>
```


Closes #43 