### PR TITLE
Retry WQP download upon error

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -119,7 +119,8 @@ p1_targets_list <- list(
   tar_target(
     p1_wqp_data_aoi,
     fetch_wqp_data(p1_site_counts_grouped, p1_char_names, wqp_args = wqp_args),
-    pattern = map(p1_site_counts_grouped)
+    pattern = map(p1_site_counts_grouped),
+    error = "continue"
   ),
   
   # Summarize the data downloaded from the WQP

--- a/1_fetch/src/fetch_wqp_data.R
+++ b/1_fetch/src/fetch_wqp_data.R
@@ -54,7 +54,9 @@ fetch_wqp_data <- function(site_counts_grouped, characteristics, wqp_args = NULL
                                    characteristicName = c(characteristics)))
   
   # Pull data
-  wqp_data <- dataRetrieval::readWQPdata(wqp_args_all)
+  wqp_data <- retry::retry(dataRetrieval::readWQPdata(wqp_args_all),
+                           when = "Error:", 
+                           max_tries = 3)
   
   # Some records return character strings when we expect numeric values, 
   # e.g. when "*Non-detect" appears in the "ResultMeasureValue" field. 

--- a/_targets.R
+++ b/_targets.R
@@ -2,7 +2,7 @@ library(targets)
 
 options(tidyverse.quiet = TRUE)
 tar_option_set(packages = c('tidyverse', 'lubridate', 'dataRetrieval', 
-                            'sf', 'xml2', 'units'))
+                            'sf', 'xml2', 'units', 'retry'))
 
 source("1_fetch.R")
 


### PR DESCRIPTION
This PR addresses #48. 

As the spatial extent or number of records requested increases, we're more likely to run into timeout errors or other issues that cause one or more branches to fail when building `p1_wqp_data_aoi`. The code changes here include:

- add a `retry()` _within_ the `fetch_wqp_data` function 
- add `error = 'continue'` to `p1_wqp_data_aoi` so that targets will continue building the branches that do work as opposed to stopping the pipeline immediately. 

I haven't committed any changes to our AOI or search arguments, but to test these changes I replaced some of the variables in _targets.R with the following:

```r
# Specify coordinates that define the spatial area of interest
# lat/lon are referenced to WGS84
coords_lon <- c(-90.333, -87.8, -89)
coords_lat <- c(42.547, 45.029, 35)

# Specify arguments to WQP queries
# see https://www.waterqualitydata.us/webservices_documentation for more information 
wqp_args <- list(sampleMedia = c("Water","water"),
                 siteType = "Lake, Reservoir, Impoundment",
                 # return sites with at least one data record
                 minresults = 1, 
                 startDateLo = start_date,
                 startDateHi = end_date)
```

The pipeline builds for me with these new values:

```r
> tar_load(p1_wqp_data_summary_csv)
> summary <- read_csv(p1_wqp_data_summary_csv, show_col_types = FALSE)
                                                                                                                                                                                 
> summary
# A tibble: 4 x 3
  CharacteristicName   sites_count results_count
  <chr>                      <dbl>         <dbl>
1 Conductivity                  33           383
2 Specific conductance         800         74801
3 Temperature, sample          601          9538
4 Temperature, water           886        235585
>
```