### PR TITLE
Map over characteristic names and grids when building `p1_wqp_inventory`

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -82,7 +82,7 @@ p1_targets_list <- list(
     inventory_wqp(grid = p1_global_grid_aoi,
                   char_names = p1_char_names,
                   wqp_args = wqp_args),
-    pattern = map(p1_global_grid_aoi)
+    pattern = cross(p1_global_grid_aoi, p1_char_names)
   ),
   
   # Subset the WQP inventory to only retain sites within the area of interest

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -82,7 +82,8 @@ p1_targets_list <- list(
     inventory_wqp(grid = p1_global_grid_aoi,
                   char_names = p1_char_names,
                   wqp_args = wqp_args),
-    pattern = cross(p1_global_grid_aoi, p1_char_names)
+    pattern = cross(p1_global_grid_aoi, p1_char_names),
+    error = "continue"
   ),
   
   # Subset the WQP inventory to only retain sites within the area of interest


### PR DESCRIPTION
This PR includes a small code change to map over characteristic names _and_ grids when building the `p1_wqp_inventory` target. This will hopefully avoid the need to rebuild full grids if, for example, we add a new parameter in _targets.R or add/remove a characteristic name from `wqp_codes.yml`.

Closes #50 