### PR TITLE
Chunk data pulls using grids, number of sites, and total records

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -104,13 +104,16 @@ p1_targets_list <- list(
     p1_site_counts,
     p1_wqp_inventory_aoi %>%
       group_by(MonitoringLocationIdentifier) %>%
-      summarize(results_count = sum(resultCount, na.rm = TRUE))
+      summarize(results_count = sum(resultCount, na.rm = TRUE),
+                grid_id = unique(grid_id))
   ),
   
   # Group the sites into reasonably sized chunks for downloading data 
   tar_target(
     p1_site_counts_grouped,
-    add_download_groups(p1_site_counts, max_sites_allowed = 500) %>%
+    add_download_groups(p1_site_counts, 
+                        max_sites = 500,
+                        max_results = 250000) %>%
       group_by(download_grp) %>%
       tar_group(),
     iteration = "group"

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -71,8 +71,9 @@ p1_targets_list <- list(
   # Inventory data available from the WQP within each of the boxes that overlap
   # the area of interest. To prevent timeout issues that result from large data 
   # requests, use {targets} dynamic branching capabilities to map the function 
-  # inventory_wqp() over each grid within p1_global_grid_aoi. {targets} will 
-  # then combine all of the grid-scale inventories into one table.
+  # inventory_wqp() over each grid within p1_global_grid_aoi. {targets} will then
+  # combine all of the grid-scale inventories into one table. See comments below
+  # associated with target p1_wqp_data_aoi regarding the use of error = 'continue'.
   tar_target(
     p1_wqp_inventory,
     # inventory_wqp() requires grid and char_names as inputs, but users can 

--- a/1_fetch/src/fetch_wqp_data.R
+++ b/1_fetch/src/fetch_wqp_data.R
@@ -23,7 +23,10 @@ add_download_groups <- function(sitecounts_df, max_sites = 500, max_results = 25
       filter(results_count > max_results) %>%
       pull(MonitoringLocationIdentifier)
     # Print a message to inform the user that some sites contain a lot of data
-    message(sprintf("results_count exceeds max_results for the following sites:\n\n%s\n",
+    message(sprintf(paste0("results_count exceeds max_results for the sites ",
+                           "below. If you are not already branching across ",
+                           "characteristic names, consider doing so to set up ",
+                           "a manageable query to WQP.\n\n%s\n"),
                     paste(sites_w_many_records, collapse="\n")))
   }
   

--- a/1_fetch/src/fetch_wqp_data.R
+++ b/1_fetch/src/fetch_wqp_data.R
@@ -23,10 +23,11 @@ add_download_groups <- function(sitecounts_df, max_sites = 500, max_results = 25
       filter(results_count > max_results) %>%
       pull(MonitoringLocationIdentifier)
     # Print a message to inform the user that some sites contain a lot of data
-    message(sprintf(paste0("results_count exceeds max_results for the sites ",
-                           "below. If you are not already branching across ",
-                           "characteristic names, consider doing so to set up ",
-                           "a manageable query to WQP.\n\n%s\n"),
+    message(sprintf(paste0("results_count exceeds max_results for the sites below. ",
+                           "Assigning data-heavy sites to their own download group to ",
+                           "set up a manageable query to WQP. If you are not already ",
+                           "branching across characteristic names, consider doing so to ",
+                           "further limit query size. \n\n%s\n"),
                     paste(sites_w_many_records, collapse="\n")))
   }
   

--- a/1_fetch/src/fetch_wqp_data.R
+++ b/1_fetch/src/fetch_wqp_data.R
@@ -5,22 +5,46 @@
 #' 
 #' @param sitecounts_df data frame containing the site identifiers and total number of
 #' records available for each site. Must contain columns `MonitoringLocationIdentifier`.
-#' @param max_sites_allowed integer indicating the maximum number of sites allowed
-#' in each download group. Defaults to 500.
+#' @param max_sites integer indicating the maximum number of sites allowed in each
+#' download group. Defaults to 500.
+#' @param max_results integer indicating the maximum number of records allowed in
+#' each download group. Defaults to 250,000.
 #' 
 #' @return returns a data frame with columns site id, the total number of records,
 #' (retains the column from `sitecounts_df`), site number, and an additional column 
 #' called `download_grp` which is made up of unique groups that enable use of 
 #' `group_by()` and then `tar_group()` for downloading.
 #' 
-add_download_groups <- function(sitecounts_df, max_sites_allowed = 500) {
+add_download_groups <- function(sitecounts_df, max_sites = 500, max_results = 250000) {
   
+  # Check whether any individual sites have a records count that exceeds `max_results`
+  if(any(sitecounts_df$results_count > max_results)){
+    sites_w_many_records <- sitecounts_df %>%
+      filter(results_count > max_results) %>%
+      pull(MonitoringLocationIdentifier)
+    # Print a message to inform the user that some sites contain a lot of data
+    message(sprintf("results_count exceeds max_results for the following sites:\n\n%s\n",
+                    paste(sites_w_many_records, collapse="\n")))
+  }
+  
+  # Within each unique grid_id, use the cumsumbinning function from the MESS
+  # package to group sites based on the cumulative sum of results_count 
+  # across sites within the grid, resetting the download group/task number 
+  # if the number of records exceeds the threshold set by `max_results`
   sitecounts_grouped <- sitecounts_df %>%
     rename(site_id = MonitoringLocationIdentifier) %>% 
+    split(.$grid_id) %>%
+    purrr::map_dfr(.f = function(df){
+      
+      df_grouped <- df %>%
+        arrange(desc(results_count)) %>%
+        mutate(task_num = MESS::cumsumbinning(x = results_count, 
+                                              threshold = max_results, 
+                                              maxgroupsize = max_sites),
+               download_grp = paste0(grid_id,"_",task_num))
+    }) %>%
     mutate(site_n = row_number()) %>%
-    # Add a column indicating which chunk a site belongs to; the number of rows
-    # in each chunk should not exceed `max_sites_allowed`
-    mutate(download_grp = ((site_n -1) %/% max_sites_allowed) + 1)
+    select(site_id, results_count, site_n, download_grp)
   
   return(sitecounts_grouped)
 

--- a/1_fetch/src/get_wqp_inventory.R
+++ b/1_fetch/src/get_wqp_inventory.R
@@ -9,6 +9,8 @@
 #' @param wqp_args list containing additional arguments to pass to whatWQPdata(),
 #' defaults to NULL. See https://www.waterqualitydata.us/webservices_documentation 
 #' for more information.  
+#' @param max_tries integer, maximum number of attempts if the data download 
+#' step returns an error. Defaults to 3.
 #' 
 #' @value returns a data frame containing sites available from the Water Quality Portal
 #' 
@@ -18,7 +20,7 @@
 #' explicitly load and attach sf package to handle geometry data in `grid`
 library(sf)
 
-inventory_wqp <- function(grid, char_names, wqp_args = NULL){
+inventory_wqp <- function(grid, char_names, wqp_args = NULL, max_tries = 3){
   
   # Get bounding box for the grid polygon
   bbox <- sf::st_bbox(grid)
@@ -36,7 +38,9 @@ inventory_wqp <- function(grid, char_names, wqp_args = NULL){
     wqp_args_all <- c(wqp_args, list(bBox = c(bbox$xmin, bbox$ymin, bbox$xmax, bbox$ymax),
                                      characteristicName = x))
     # query WQP
-    dataRetrieval::whatWQPdata(wqp_args_all) %>%
+    retry::retry(dataRetrieval::whatWQPdata(wqp_args_all),
+                 when = "Error:", 
+                 max_tries = max_tries) %>%
       mutate(CharacteristicName = x, grid_id = grid$id)
   }) %>%
     bind_rows()

--- a/1_fetch/src/get_wqp_inventory.R
+++ b/1_fetch/src/get_wqp_inventory.R
@@ -27,7 +27,8 @@ inventory_wqp <- function(grid, char_names, wqp_args = NULL){
   char_names <- as.character(unlist(char_names))
   
   # Print time-specific message so user can see progress
-  message(sprintf('Inventorying WQP data for grid %s', grid$id))
+  message(sprintf('Inventorying WQP data for grid %s, %s', 
+                  grid$id, char_names))
 
   # Inventory available WQP data
   wqp_inventory <- lapply(char_names,function(x){

--- a/_targets.R
+++ b/_targets.R
@@ -2,7 +2,7 @@ library(targets)
 
 options(tidyverse.quiet = TRUE)
 tar_option_set(packages = c('tidyverse', 'lubridate', 'dataRetrieval', 
-                            'sf', 'xml2', 'units', 'retry'))
+                            'sf', 'xml2', 'units', 'retry', 'MESS'))
 
 source("1_fetch.R")
 


### PR DESCRIPTION
This PR addresses #36 and is related to discussion point 5 in #41.

The following code changes are included here:

- retain `grid_id` in `p1_site_counts` so that we can use the grid information to further group the sites for download.
- edits to the `add_download_groups` function to to group sites based on the cumulative sum of `results_count`  across sites within each grid, resetting the download group/task number if the number of records exceeds the threshold set by the user in `max_results` (defaults to 250,000).

I haven't committed any changes to _targets.R, but was using the following parameters from before for testing:

```r
# Specify coordinates that define the spatial area of interest
# lat/lon are referenced to WGS84
coords_lon <- c(-96.333, -87.8, -89)
coords_lat <- c(42.547, 45.029, 35)

# Specify arguments to WQP queries
# see https://www.waterqualitydata.us/webservices_documentation for more information 
wqp_args <- list(sampleMedia = c("Water","water"),
                 siteType = "Lake, Reservoir, Impoundment",
                 # return sites with at least one data record
                 minresults = 1, 
                 startDateLo = start_date,
                 startDateHi = end_date)
```