### PR TITLE
Add handling for site identifiers containing "/" 

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -104,9 +104,10 @@ p1_targets_list <- list(
   tar_target(
     p1_site_counts,
     p1_wqp_inventory_aoi %>%
-      group_by(MonitoringLocationIdentifier) %>%
+      group_by(MonitoringLocationIdentifier, lat, lon, datum) %>%
       summarize(results_count = sum(resultCount, na.rm = TRUE),
-                grid_id = unique(grid_id))
+                grid_id = unique(grid_id),
+                .groups = 'drop')
   ),
   
   # Group the sites into reasonably sized chunks for downloading data 

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -104,9 +104,8 @@ p1_targets_list <- list(
   tar_target(
     p1_site_counts,
     p1_wqp_inventory_aoi %>%
-      group_by(MonitoringLocationIdentifier, lat, lon, datum) %>%
+      group_by(MonitoringLocationIdentifier, lon, lat, datum, grid_id) %>%
       summarize(results_count = sum(resultCount, na.rm = TRUE),
-                grid_id = unique(grid_id),
                 .groups = 'drop')
   ),
   

--- a/1_fetch/src/fetch_wqp_data.R
+++ b/1_fetch/src/fetch_wqp_data.R
@@ -67,17 +67,16 @@ add_download_groups <- function(sitecounts_df, max_sites = 500, max_results = 25
     }) %>%
     mutate(pull_by_id = TRUE)
   
-  # Assign a separate task number and download group for all sites with 
-  # bad identifiers within a grid
+  # Assign a separate task number and download group for each site with bad ids
   sitecounts_grouped_bad_ids <- sitecounts_bad_ids %>%
-    group_by(grid_id) %>%
+    group_by(site_id) %>%
     mutate(task_num = max(sitecounts_grouped_good_ids$task_num) + cur_group_id(),
            download_grp = paste0(grid_id,"_",task_num),
            pull_by_id = FALSE) %>%
     ungroup()
   
-  # Combine all sites back together, now with assigned download_grp id's
-  # and format columns
+  # Combine all sites back together (now with assigned download_grp id's) and
+  # format columns
   sitecounts_grouped_out <- sitecounts_grouped_good_ids %>%
     bind_rows(sitecounts_grouped_bad_ids) %>%
     arrange(download_grp) %>%

--- a/1_fetch/src/fetch_wqp_data.R
+++ b/1_fetch/src/fetch_wqp_data.R
@@ -41,7 +41,7 @@ add_download_groups <- function(sitecounts_df, max_sites = 500, max_results = 25
     message(sprintf(paste0("Some site identifiers contain undesired characters and cannot ",
                            "be parsed by WQP. Assigning %s sites and %s records with bad ",
                            "identifiers to their own download groups so that they can be ",
-                           "queried separately."),
+                           "queried separately using a different method."),
                     nrow(sitecounts_bad_ids), sum(sitecounts_bad_ids$results_count)))
   }
   

--- a/1_fetch/src/fetch_wqp_data.R
+++ b/1_fetch/src/fetch_wqp_data.R
@@ -17,7 +17,8 @@ identify_bad_ids <- function(sitecounts_df){
     rename(site_id = MonitoringLocationIdentifier) %>% 
     # check that string format matches regex used in WQP
     mutate(site_id_regex = stringr::str_extract(site_id, "[\\w]+\\-.*\\S")) %>%
-    filter(site_id != site_id_regex | grepl("/", site_id))
+    filter(site_id != site_id_regex | grepl("/", site_id)) %>%
+    select(-site_id_regex)
   
   if(nrow(sitecounts_bad_ids) > 0){
     message(sprintf(paste0("Some site identifiers contain undesired characters and cannot ",

--- a/1_fetch/src/fetch_wqp_data.R
+++ b/1_fetch/src/fetch_wqp_data.R
@@ -150,7 +150,7 @@ fetch_wqp_data <- function(site_counts_grouped, characteristics, wqp_args = NULL
                   max(site_counts_grouped$site_n)))
   
   # Define arguments for readWQPdata
-  # sites with pull_by_id = FALSE contain cannot be queried by their site
+  # sites with pull_by_id = FALSE cannot be queried by their site
   # identifiers because of undesired characters that will cause the WQP
   # query to fail. For those sites, query WQP by adding a small bounding
   # box around the site(s) and including bBox in the wqp_args.

--- a/1_fetch/src/fetch_wqp_data.R
+++ b/1_fetch/src/fetch_wqp_data.R
@@ -15,7 +15,9 @@ identify_bad_ids <- function(sitecounts_df){
   # downloading the data from WQP
   sitecounts_bad_ids <- sitecounts_df %>%
     rename(site_id = MonitoringLocationIdentifier) %>% 
-    filter(grepl("/|ALABAMACOUSHATTATRIBE.TX_WQX|RCE WRP-", site_id))
+    # check that string format matches regex used in WQP
+    mutate(site_id_regex = stringr::str_extract(site_id, "[\\w]+\\-.*\\S")) %>%
+    filter(site_id != site_id_regex | grepl("/", site_id))
   
   if(nrow(sitecounts_bad_ids) > 0){
     message(sprintf(paste0("Some site identifiers contain undesired characters and cannot ",

--- a/1_fetch/src/fetch_wqp_data.R
+++ b/1_fetch/src/fetch_wqp_data.R
@@ -78,9 +78,8 @@ add_download_groups <- function(sitecounts_df, max_sites = 500, max_results = 25
   
   # Combine all sites back together, now with assigned download_grp id's
   # and format columns
-  sitecounts_grouped <- bind_rows(sitecounts_grouped_good_ids,
-                                  sitecounts_grouped_bad_ids)
-  sitecounts_grouped_out <- sitecounts_grouped %>%
+  sitecounts_grouped_out <- sitecounts_grouped_good_ids %>%
+    bind_rows(sitecounts_grouped_bad_ids) %>%
     arrange(download_grp) %>%
     mutate(site_n = row_number()) %>% 
     select(site_id, lat, lon, datum, results_count, site_n, download_grp, pull_by_id)

--- a/1_fetch/src/fetch_wqp_data.R
+++ b/1_fetch/src/fetch_wqp_data.R
@@ -31,11 +31,29 @@ add_download_groups <- function(sitecounts_df, max_sites = 500, max_results = 25
                     paste(sites_w_many_records, collapse="\n")))
   }
   
+  # Check whether any sites have identifiers that are likely to cause problems when
+  # downloading the data from WQP
+  sitecounts_bad_ids <- sitecounts_df %>%
+    rename(site_id = MonitoringLocationIdentifier) %>% 
+    filter(grepl("/|ALABAMACOUSHATTATRIBE.TX_WQX|RCE WRP-", site_id))
+  
+  if(length(sitecounts_bad_ids$site_id) > 0){
+    message(sprintf(paste0("Some site identifiers contain undesired characters and cannot ",
+                           "be parsed by WQP. Assigning %s sites and %s records with bad ",
+                           "identifiers to their own download groups so that they can be ",
+                           "queried separately."),
+                    nrow(sitecounts_bad_ids), sum(sitecounts_bad_ids$results_count)))
+  }
+  
+  # Subset 'good' sites with identifiers that can be parsed by WQP
+  sitecounts_good_ids <- sitecounts_df %>%
+    filter(!MonitoringLocationIdentifier %in% sitecounts_bad_ids$site_id)
+  
   # Within each unique grid_id, use the cumsumbinning function from the MESS
   # package to group sites based on the cumulative sum of results_count 
   # across sites within the grid, resetting the download group/task number 
   # if the number of records exceeds the threshold set by `max_results`
-  sitecounts_grouped <- sitecounts_df %>%
+  sitecounts_grouped_good_ids <- sitecounts_good_ids %>%
     rename(site_id = MonitoringLocationIdentifier) %>% 
     split(.$grid_id) %>%
     purrr::map_dfr(.f = function(df){
@@ -47,12 +65,63 @@ add_download_groups <- function(sitecounts_df, max_sites = 500, max_results = 25
                                               maxgroupsize = max_sites),
                download_grp = paste0(grid_id,"_",task_num))
     }) %>%
-    mutate(site_n = row_number()) %>%
-    select(site_id, results_count, site_n, download_grp)
+    mutate(pull_id = TRUE)
   
-  return(sitecounts_grouped)
+  # Assign a separate task number and download group for all sites with 
+  # bad identifiers within a grid
+  sitecounts_grouped_bad_ids <- sitecounts_bad_ids %>%
+    group_by(grid_id) %>%
+    mutate(task_num = max(sitecounts_grouped_good_ids$task_num) + cur_group_id(),
+           download_grp = paste0(grid_id,"_",task_num),
+           pull_id = FALSE) %>%
+    ungroup()
+  
+  # Combine all sites back together, now with assigned download_grp id's
+  # and format columns
+  sitecounts_grouped <- bind_rows(sitecounts_grouped_good_ids,
+                                  sitecounts_grouped_bad_ids)
+  sitecounts_grouped_out <- sitecounts_grouped %>%
+    arrange(download_grp) %>%
+    mutate(site_n = row_number()) %>% 
+    select(site_id, lat, lon, datum, results_count, site_n, download_grp, pull_id)
+  
+  return(sitecounts_grouped_out)
 
 }
+
+
+
+#' Function to return a small bounding box around site(s)
+#' 
+#' @details Some site identifiers contain undesired characters and cannot be
+#' parsed by WQP. This function creates a small bounding box around the 
+#' site(s) for the purposes of querying WQP by bBox rather than site id. 
+#' 
+#' @param sites data frame containing at minimum columns lat, lon, and datum
+#' @param buffer_dist_degrees double; value indicating how large of a buffer
+#' should be added to the site(s). Bounding box will be computed in WGS84 and
+#' units are in degrees. Defaults to 0.005 degrees (~500 m).
+#' 
+create_site_bbox <- function(sites, buffer_dist_degrees = 0.005){
+  
+  # assume unknown crs (datum equals "UNKNWN", "OTHER") correspond with WGS84
+  epsg_in <- case_when(unique(sites$datum) == "NAD83" ~ 4269,
+                       unique(sites$datum) == "WGS84" ~ 4326,
+                       unique(sites$datum) == "NAD27" ~ 4267,
+                       unique(sites$datum) == "UNKWN" ~ 4326,
+                       unique(sites$datum) == "OTHER" ~ 4326)
+  
+  # create a small buffer around the site(s) and then compute the bounding box
+  site_bbox <- sites %>%
+    sf::st_as_sf(coords = c("lon","lat"), crs = epsg_in) %>%
+    sf::st_transform(4326) %>%
+    sf::st_buffer(buffer_dist_degrees) %>%
+    sf::st_bbox()
+  
+  return(site_bbox)
+  
+}
+  
 
 
 #' Download data from the Water Quality Portal
@@ -61,7 +130,9 @@ add_download_groups <- function(sitecounts_df, max_sites = 500, max_results = 25
 #'  
 #' @param site_counts_grouped data frame containing site identifiers, the 
 #' total number of records, site numbers, and a download group assigned
-#' for each site. Must contain columns `site_id` and `site_n`.
+#' for each site. Must contain columns `site_id`, `site_n`, and `pull_id`.
+#' `pull_id` is logical and indicates whether data should be downloaded
+#' using site identifiers or by querying a small bounding box around the site.
 #' @param characteristics vector of character strings indicating which WQP
 #' CharacteristicName to query
 #' @param wqp_args list containing additional arguments to pass to whatWQPdata(),
@@ -80,19 +151,34 @@ fetch_wqp_data <- function(site_counts_grouped, characteristics, wqp_args = NULL
                   max(site_counts_grouped$site_n)))
   
   # Define arguments for readWQPdata
-  wqp_args_all <- c(wqp_args, list(siteid = site_counts_grouped$site_id,
-                                   characteristicName = c(characteristics)))
+  # sites with pull_id = FALSE contain cannot be queried by their site
+  # identifiers because of undesired characters that will cause the WQP
+  # query to fail. For those sites, query WQP by adding a small bounding
+  # box around the site(s) and including bBox in the wqp_args.
+  if(unique(site_counts_grouped$pull_id)){
+    wqp_args_all <- c(wqp_args, 
+                      list(siteid = site_counts_grouped$site_id,
+                           characteristicName = c(characteristics)))
+  } else {
+    wqp_args_all <- c(wqp_args, 
+                      list(bBox = create_site_bbox(site_counts_grouped),
+                           characteristicName = c(characteristics)))
+  }
   
   # Pull data, retrying up to the number of times indicated by `max_tries`
   wqp_data <- retry::retry(dataRetrieval::readWQPdata(wqp_args_all),
                            when = "Error:", 
                            max_tries = max_tries)
   
-  # Some records return character strings when we expect numeric values, 
-  # e.g. when "*Non-detect" appears in the "ResultMeasureValue" field. 
+  # We applied special handling for sites with pull_id = FALSE (see comments
+  # above). Filter wqp_data to only include sites requested in site_counts_grouped
+  # in case our bounding box approach picked up any additional, undesired sites. 
+  # In addition, some records return character strings when we expect numeric 
+  # values, e.g. when "*Non-detect" appears in the "ResultMeasureValue" field. 
   # For now, consider all columns to be character so that individual data
   # frames returned from fetch_wqp_data can be joined together. 
   wqp_data_out <- wqp_data %>%
+    filter(MonitoringLocationIdentifier %in% site_counts_grouped$site_id) %>%
     mutate(across(everything(), as.character))
   
   return(wqp_data_out)

--- a/1_fetch/src/fetch_wqp_data.R
+++ b/1_fetch/src/fetch_wqp_data.R
@@ -37,7 +37,7 @@ add_download_groups <- function(sitecounts_df, max_sites = 500, max_results = 25
     rename(site_id = MonitoringLocationIdentifier) %>% 
     filter(grepl("/|ALABAMACOUSHATTATRIBE.TX_WQX|RCE WRP-", site_id))
   
-  if(length(sitecounts_bad_ids$site_id) > 0){
+  if(nrow(sitecounts_bad_ids) > 0){
     message(sprintf(paste0("Some site identifiers contain undesired characters and cannot ",
                            "be parsed by WQP. Assigning %s sites and %s records with bad ",
                            "identifiers to their own download groups so that they can be ",

--- a/1_fetch/src/get_wqp_inventory.R
+++ b/1_fetch/src/get_wqp_inventory.R
@@ -156,17 +156,15 @@ subset_inventory <- function(wqp_inventory, aoi_sf, buffer_dist_m = 0){
     sf::st_filter(y = sf::st_transform(aoi_sf, sf::st_crs(.)),
                   .predicate = st_is_within_distance,
                   dist = units::set_units(buffer_dist_m, m)) %>%
+    mutate(lon = sf::st_coordinates(.)[,1],
+           lat = sf::st_coordinates(.)[,2]) %>%
     sf::st_drop_geometry() %>%
-    pull(MonitoringLocationIdentifier) %>%
-    unique()
-  
-  wqp_inventory_aoi <- wqp_inventory %>%
-    filter(MonitoringLocationIdentifier %in% queried_sites_aoi)
+    select(c(any_of(names(wqp_inventory)), datum))
   
   message(sprintf("Returned %s sites within area of interest.",
-                  length(queried_sites_aoi)))
+                  length(queried_sites_aoi$MonitoringLocationIdentifier)))
   
-  return(wqp_inventory_aoi)
+  return(queried_sites_aoi)
   
 }
 


### PR DESCRIPTION
This PR makes the following code changes to download data for sites with undesired characters (like "/") in their identifier names:

- edits to `subset_inventory()` to return 'harmonized' lat/lon coordinates when building `p1_wqp_inventory_aoi`. The idea is that we can retain and use the values downstream for creating small bounding boxes around sites if needed.
-  edits to `add_download_groups()` to look for sites that are likely to cause problems when downloading the data and to add a new column, `pull_id`, that will ultimately dictate whether we pull the data by site identifier or need to apply special handling to download the data.
- adds a new function, `create_site_bbox()` that can be called within `fetch_wqp_data()` if sites require special handling. This function adds a "small" bounding box around the site(s) that can be used as input to `bBox` in a WQP query.

The code changes here should not impact the number of sites/records for our original area of interest currently in _targets.R. In stress testing some of our data pull steps we've used other arguments that are copied below. These alternate arguments return sites with "/" in their site identifiers. The pipeline should run with the changes in this PR.

```r
# Define which parameter groups (and CharacteristicNames) to return from WQP 
# options for parameter groups are represented in first level of 1_fetch/cfg/wqp_codes.yml
param_groups_select <- c('temperature')

# Specify coordinates that define the spatial area of interest
# lat/lon are referenced to WGS84
coords_lon <- c(-96.333, -87.8, -89)
coords_lat <- c(42.547, 45.029, 35)

# Specify arguments to WQP queries
# see https://www.waterqualitydata.us/webservices_documentation for more information 
wqp_args <- list(sampleMedia = c("Water","water"),
                 siteType = "Lake, Reservoir, Impoundment",
                 # return sites with at least one data record
                 minresults = 1, 
                 startDateLo = start_date,
                 startDateHi = end_date)
```

There might be scenarios where people want to use this fix in their own WQP workflows. I'm not sure how easy it would be to pull this out, but I'd welcome any suggestions you have for making this solution more generalizable and/or modular. 

Closes #56