### PR TITLE
Add optional variable to force pipeline rebuild

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -76,13 +76,16 @@ p1_targets_list <- list(
   # associated with target p1_wqp_data_aoi regarding the use of error = 'continue'.
   tar_target(
     p1_wqp_inventory,
+    {
     # inventory_wqp() requires grid and char_names as inputs, but users can 
     # also pass additional arguments to WQP, e.g. sampleMedia or siteType, using 
-    # wqp_args. Below, wqp_args is defined in _targets.R. See documentation
-    # in 1_fetch/src/get_wqp_inventory.R for further details.
+    # wqp_args. See documentation in 1_fetch/src/get_wqp_inventory.R for further
+    # details. Below, wqp_args and last_forced_build are defined in _targets.R. 
+    force_build <- last_forced_build
     inventory_wqp(grid = p1_global_grid_aoi,
                   char_names = p1_char_names,
-                  wqp_args = wqp_args),
+                  wqp_args = wqp_args)
+    },
     pattern = cross(p1_global_grid_aoi, p1_char_names),
     error = "continue"
   ),

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -80,8 +80,9 @@ p1_targets_list <- list(
     # inventory_wqp() requires grid and char_names as inputs, but users can 
     # also pass additional arguments to WQP, e.g. sampleMedia or siteType, using 
     # wqp_args. See documentation in 1_fetch/src/get_wqp_inventory.R for further
-    # details. Below, wqp_args and last_forced_build are defined in _targets.R. 
-    force_build <- last_forced_build
+    # details. Below, wqp_args and last_forced_build are dependencies that get
+    # defined in _targets.R. 
+    last_forced_build
     inventory_wqp(grid = p1_global_grid_aoi,
                   char_names = p1_char_names,
                   wqp_args = wqp_args)

--- a/_targets.R
+++ b/_targets.R
@@ -29,6 +29,12 @@ wqp_args <- list(sampleMedia = c("Water","water"),
                  startDateLo = start_date,
                  startDateHi = end_date)
 
+# [Optional] variable that can be edited to force rebuild of the entire data pipeline,
+# including inventory, download, and harmonization steps. Leaving as is will use the
+# pipeline's built-in behavior to only re-inventory and re-download data for subsets
+# of the data that have changed. 
+last_forced_build <- "2022-07-01"
+
 # Return the complete list of targets
 c(p1_targets_list)
 

--- a/_targets.R
+++ b/_targets.R
@@ -29,10 +29,15 @@ wqp_args <- list(sampleMedia = c("Water","water"),
                  startDateLo = start_date,
                  startDateHi = end_date)
 
-# [Optional] variable that can be edited to force rebuild of the entire data pipeline,
-# including inventory, download, and harmonization steps. Leaving as is will use the
-# pipeline's built-in behavior to only re-inventory and re-download data for subsets
-# of the data that have changed. 
+# [Optional] variable that can be edited to force rebuild of the data inventory.
+# Leaving as is will use the pipeline's built-in behavior to only re-inventory 
+# data for subsets of the input data that have changed, for example, if the area
+# of interest were expanded and now spans more grids. If using `last_forced_build`
+# below, be aware that downstream pipeline steps, including data download and
+# harmonization, would also re-build IF the inventory outputs change compared to 
+# their previous state. Therefore, editing this variable does not guarantee that 
+# updated values will be downloaded from WQP if the inventory, including site ids 
+# and number of records, has not changed from the previous build. 
 last_forced_build <- "2022-07-01"
 
 # Return the complete list of targets


### PR DESCRIPTION
This PR adds a new (optional) variable, `last_forced_build` that is a dependency of `p1_wqp_inventory`. This variable provides users the option to use it to force a rebuild of the data inventory/download steps, or to leave as-is and use the pipeline's built-in behavior. Updating `last_forced_build` would allows users to say, _"I queried WQP on X date"_, for example.

Closes #59 