### PR TITLE
Address 'greedy' rebuilds in `p1_wqp_data_aoi`

### DIFF
--- a/1_fetch/src/fetch_wqp_data.R
+++ b/1_fetch/src/fetch_wqp_data.R
@@ -103,8 +103,7 @@ add_download_groups <- function(sitecounts_df, max_sites = 500, max_results = 25
   sitecounts_grouped_out <- sitecounts_grouped_good_ids %>%
     bind_rows(sitecounts_grouped_bad_ids) %>%
     arrange(download_grp) %>%
-    mutate(site_n = row_number()) %>% 
-    select(site_id, lat, lon, datum, results_count, site_n, download_grp, pull_by_id)
+    select(site_id, lat, lon, datum, results_count, download_grp, pull_by_id) 
   
   return(sitecounts_grouped_out)
 
@@ -167,9 +166,8 @@ create_site_bbox <- function(sites, buffer_dist_degrees = 0.005){
 #' 
 fetch_wqp_data <- function(site_counts_grouped, characteristics, wqp_args = NULL, max_tries = 3){
   
-  message(sprintf("Retrieving WQP data for sites %s:%s",
-                  min(site_counts_grouped$site_n), 
-                  max(site_counts_grouped$site_n)))
+  message(sprintf("Retrieving WQP data for %s sites in group %s",
+                  nrow(site_counts_grouped), unique(site_counts_grouped$download_grp)))
   
   # Define arguments for readWQPdata
   # sites with pull_by_id = FALSE cannot be queried by their site

--- a/1_fetch/src/get_wqp_inventory.R
+++ b/1_fetch/src/get_wqp_inventory.R
@@ -101,8 +101,8 @@ transform_site_locations <- function(sites, crs_out = "WGS84"){
         sites_transformed <- x %>%
           sf::st_as_sf(coords=c("lon","lat"), crs = epsg_in) %>%
           sf::st_transform(epsg_out) %>%
-          mutate(lon_new = sf::st_coordinates(.)[,1],
-                 lat_new = sf::st_coordinates(.)[,2],
+          mutate(lon_new = as.numeric(sf::st_coordinates(.)[,1]),
+                 lat_new = as.numeric(sf::st_coordinates(.)[,2]),
                  datum_new = crs_out) %>%
           sf::st_drop_geometry() %>%
           select(-datum) %>%
@@ -156,8 +156,8 @@ subset_inventory <- function(wqp_inventory, aoi_sf, buffer_dist_m = 0){
     sf::st_filter(y = sf::st_transform(aoi_sf, sf::st_crs(.)),
                   .predicate = st_is_within_distance,
                   dist = units::set_units(buffer_dist_m, m)) %>%
-    mutate(lon = sf::st_coordinates(.)[,1],
-           lat = sf::st_coordinates(.)[,2]) %>%
+    mutate(lon = as.numeric(sf::st_coordinates(.)[,1]),
+           lat = as.numeric(sf::st_coordinates(.)[,2])) %>%
     sf::st_drop_geometry() %>%
     select(c(any_of(names(wqp_inventory)), datum))
   


### PR DESCRIPTION
This PR makes the following code changes to address greedy rebuilds in `p1_wqp_data_aoi`:

- coerce lat/lon values defined using `sf::st_coordinates()` to numeric in `get_wqp_inventory.R`
- omit the `site_n` field from `p1_site_counts_grouped`. I edited the status message in `fetch_wqp_data()` to print the number of sites downloaded for each group, which is equally informative for the user but simplifies `p1_site_counts_grouped` a bit and reduces the odds that a re-build will be triggered unexpectedly.

I tried this again using the inputs described in #63, and am now seeing the expected behavior that some branches are skipped when building `p1_wqp_data_aoi` and only those download groups associated with the grids ending in "2" are re-downloaded (because the inventory for those grids changed):

```r
...
* start target p1_site_counts_grouped
* built target p1_site_counts_grouped
* start branch p1_wqp_data_aoi_4cddb205
Retrieving WQP data for 83 sites in group 11572_1
* built branch p1_wqp_data_aoi_4cddb205
v skip branch p1_wqp_data_aoi_ae655ff2
* start branch p1_wqp_data_aoi_28944af3
Retrieving WQP data for 500 sites in group 11752_1
* built branch p1_wqp_data_aoi_28944af3
* start branch p1_wqp_data_aoi_c746b820
Retrieving WQP data for 500 sites in group 11752_2
* built branch p1_wqp_data_aoi_c746b820
* start branch p1_wqp_data_aoi_47bceec2
Retrieving WQP data for 206 sites in group 11752_3
* built branch p1_wqp_data_aoi_47bceec2
v skip branch p1_wqp_data_aoi_5233719f
* built pattern p1_wqp_data_aoi
* start target p1_wqp_data_summary_csv
All good! The expected number of records from the WQP inventory matches the data pull for all characteristics.
* built target p1_wqp_data_summary_csv
* end pipeline: 1.249 minutes
```



Closes #63 