### PR TITLE
Map over characteristic names when building the WQP download target

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -138,7 +138,7 @@ p1_targets_list <- list(
   tar_target(
     p1_wqp_data_aoi,
     fetch_wqp_data(p1_site_counts_grouped, p1_char_names, wqp_args = wqp_args),
-    pattern = map(p1_site_counts_grouped),
+    pattern = cross(p1_site_counts_grouped, p1_char_names),
     error = "continue"
   ),
   

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -126,15 +126,16 @@ p1_targets_list <- list(
 
   # Map over groups of sites to download data.
   # Note that because error = 'continue', {targets} will attempt to build all 
-  # of the "branches" represented in p1_site_counts_grouped, even if one branch 
-  # returns an error. This way, we will not need to re-build branches that have
-  # already run successfully. However, if a branch fails, {targets} will throw
-  # an error reading `could not load dependencies of [immediate downstream target]. invalid 
-  # 'description' argument` because it cannot merge the individual branches and so did not  
-  # complete the branching target. The error(s) associated with the failed branch will therefore 
-  # need to be resolved before the full target can be successfully built. A 
-  # common reason a branch may fail is due to WQP timeout errors. Timeout errors 
-  # can sometimes be resolved by waiting a few hours and retrying tar_make().
+  # of the "branches" represented by each unique combination of characteristic 
+  # name and download group, even if one branch returns an error. This way, 
+  # we will not need to re-build branches that have already run successfully. 
+  # However, if a branch fails, {targets} will throw an error reading `could
+  # not load dependencies of [immediate downstream target]. invalid 'description'
+  # argument` because it cannot merge the individual branches and so did not  
+  # complete the branching target. The error(s) associated with the failed branch 
+  # will therefore need to be resolved before the full target can be successfully 
+  # built. A common reason a branch may fail is due to WQP timeout errors. Timeout 
+  # errors can sometimes be resolved by waiting a few hours and retrying tar_make().
   tar_target(
     p1_wqp_data_aoi,
     fetch_wqp_data(p1_site_counts_grouped, p1_char_names, wqp_args = wqp_args),

--- a/1_fetch/src/fetch_wqp_data.R
+++ b/1_fetch/src/fetch_wqp_data.R
@@ -171,8 +171,9 @@ create_site_bbox <- function(sites, buffer_dist_degrees = 0.005){
 fetch_wqp_data <- function(site_counts_grouped, characteristics, wqp_args = NULL, 
                            max_tries = 3, verbose = FALSE){
   
-  message(sprintf("Retrieving WQP data for %s sites in group %s",
-                  nrow(site_counts_grouped), unique(site_counts_grouped$download_grp)))
+  message(sprintf("Retrieving WQP data for %s sites in group %s, %s",
+                  nrow(site_counts_grouped), unique(site_counts_grouped$download_grp), 
+                  characteristics))
   
   # Define arguments for readWQPdata
   # sites with pull_by_id = FALSE cannot be queried by their site
@@ -204,11 +205,13 @@ fetch_wqp_data <- function(site_counts_grouped, characteristics, wqp_args = NULL
     pull_data(wqp_args_all)
     },
     message = function(msg) {
-      messages <<- c(messages, msg)
-      tryInvokeRestart('muffleMessage')
+      messages <<- c(messages, msg$message)
+      if(startsWith(conditionMessage(msg), "The following url returned no data")|
+         startsWith(conditionMessage(msg), "https://")){
+        invokeRestart('muffleMessage')}
     })
   if(verbose) message(messages)
-  
+
   # We applied special handling for sites with pull_by_id = FALSE (see comments
   # above). Filter wqp_data to only include sites requested in site_counts_grouped
   # in case our bounding box approach picked up any additional, undesired sites. 

--- a/1_fetch/src/fetch_wqp_data.R
+++ b/1_fetch/src/fetch_wqp_data.R
@@ -198,19 +198,13 @@ fetch_wqp_data <- function(site_counts_grouped, characteristics, wqp_args = NULL
                  max_tries = max_tries)
   }
   
-  # Now pull the data. Capture messages returned from the call to readWQPdata. 
-  # If verbose == TRUE, print all captured messages.
-  messages <- list()
-  wqp_data <- withCallingHandlers({
-    pull_data(wqp_args_all)
-    },
-    message = function(msg) {
-      messages <<- c(messages, msg$message)
-      if(startsWith(conditionMessage(msg), "The following url returned no data")|
-         startsWith(conditionMessage(msg), "https://")){
-        invokeRestart('muffleMessage')}
-    })
-  if(verbose) message(messages)
+  # Now pull the data. If verbose == TRUE, print all messages from dataRetrieval,
+  # otherwise, suppress messages.
+  if(verbose) {
+    wqp_data <- pull_data(wqp_args_all)
+  } else {
+    wqp_data <- suppressMessages(pull_data(wqp_args_all))
+  }
 
   # We applied special handling for sites with pull_by_id = FALSE (see comments
   # above). Filter wqp_data to only include sites requested in site_counts_grouped

--- a/1_fetch/src/fetch_wqp_data.R
+++ b/1_fetch/src/fetch_wqp_data.R
@@ -160,11 +160,16 @@ create_site_bbox <- function(sites, buffer_dist_degrees = 0.005){
 #' for more information.  
 #' @param max_tries integer, maximum number of attempts if the data download 
 #' step returns an error. Defaults to 3.
+#' @param verbose logical, indicates whether messages from dataRetrieval should 
+#' be printed to the console in the event that a query returns no data. Defaults 
+#' to FALSE. Note that `verbose` only handles messages, and dataRetrieval errors 
+#' or warnings will still get passed up to `fetch_wqp_data`. 
 #' 
 #' @return returns a data frame containing data downloaded from the Water Quality Portal, 
 #' where each row represents a unique data record. 
 #' 
-fetch_wqp_data <- function(site_counts_grouped, characteristics, wqp_args = NULL, max_tries = 3){
+fetch_wqp_data <- function(site_counts_grouped, characteristics, wqp_args = NULL, 
+                           max_tries = 3, verbose = FALSE){
   
   message(sprintf("Retrieving WQP data for %s sites in group %s",
                   nrow(site_counts_grouped), unique(site_counts_grouped$download_grp)))
@@ -184,10 +189,25 @@ fetch_wqp_data <- function(site_counts_grouped, characteristics, wqp_args = NULL
                            characteristicName = c(characteristics)))
   }
   
-  # Pull data, retrying up to the number of times indicated by `max_tries`
-  wqp_data <- retry::retry(dataRetrieval::readWQPdata(wqp_args_all),
-                           when = "Error:", 
-                           max_tries = max_tries)
+  # Define function to pull data, retrying up to the number of times
+  # indicated by `max_tries`
+  pull_data <- function(x){
+    retry::retry(dataRetrieval::readWQPdata(x),
+                 when = "Error:", 
+                 max_tries = max_tries)
+  }
+  
+  # Now pull the data. Capture messages returned from the call to readWQPdata. 
+  # If verbose == TRUE, print all captured messages.
+  messages <- list()
+  wqp_data <- withCallingHandlers({
+    pull_data(wqp_args_all)
+    },
+    message = function(msg) {
+      messages <<- c(messages, msg)
+      tryInvokeRestart('muffleMessage')
+    })
+  if(verbose) message(messages)
   
   # We applied special handling for sites with pull_by_id = FALSE (see comments
   # above). Filter wqp_data to only include sites requested in site_counts_grouped


### PR DESCRIPTION
This PR adds the following code changes:

- use `cross()` in the target definition for `p1_wqp_data_aoi` to map over each unique characteristic name and download group. This change is motivated by the fact that we want to only re-build the data download target for slices of the inventory that have actually changed since the last build. 
- adds condition handling to `fetch_wqp_data()` to allow users the option to suppress `'The following url returned no data:' ` messages from dataRetrieval using a `verbose` argument that defaults to FALSE. See #65 for further details.

Note that the code changes here should not affect the output of the pipeline, so I'm still seeing the values below when running the pipeline using the arguments that are committed in `_targets.R`:

```r
> tar_load(p1_wqp_data_summary_csv)
> wqp_data_summary <- read_csv(p1_wqp_data_summary_csv, show_col_types = FALSE)
                                                                                                                                                                     
> wqp_data_summary
# A tibble: 4 x 3
  CharacteristicName                              sites_count results_count
  <chr>                                                 <dbl>         <dbl>
1 Conductivity                                              4             7
2 Specific conductance                                    494         11438
3 Specific Conductance, Calculated/Measured Ratio           2            48
4 Temperature, water                                      504          8773
> 
```

Closes #65 