### PR TITLE
Convert select columns back to numeric

### DIFF
--- a/1_inventory/src/summarize_wqp_records.R
+++ b/1_inventory/src/summarize_wqp_records.R
@@ -67,8 +67,8 @@ summarize_wqp_data <- function(wqp_inventory_summary_csv, wqp_data, fileout){
   # Compare WQP inventory summary with data pull 
   compare_summaries <- wqp_summary %>%
     left_join(wqp_inventory_summary, by = "CharacteristicName") %>%
-    mutate(results_diff = n_sites_expected - n_records,
-           sites_diff = n_records_expected - n_sites)
+    mutate(results_diff = n_records_expected - n_records,
+           sites_diff = n_sites_expected - n_sites)
   
   msg_suggest <- "Check that wqp_args are the same for both p1_wqp_inventory and p1_wqp_data_aoi. 
   In addition, check whether the inventory is outdated by running tar_outdated() 

--- a/3_harmonize.R
+++ b/3_harmonize.R
@@ -8,8 +8,10 @@ p3_targets_list <- list(
   # not be parsed as numeric. The default option is to format "ResultMeasureValue" 
   # and "DetectionQuantitationLimitMeasure.MeasureValue" to numeric, but additional
   # variables can be added using the `vars_to_numeric` argument in format_columns().
-  # The default option is to retain all columns, but undesired variables can also be 
-  # dropped from the WQP dataset using the optional `drop_vars` argument. 
+  # For any columns parsed to numeric, the original entries are retained in columns
+  # ending in "_original." By default, format_columns() will retain all columns, 
+  # but undesired variables can also be dropped from the WQP dataset using the 
+  # optional `drop_vars` argument. 
   tar_target(
     p3_wqp_data_aoi_formatted,
     format_columns(p2_wqp_data_aoi, save_dir = "3_harmonize/out")

--- a/3_harmonize.R
+++ b/3_harmonize.R
@@ -1,7 +1,18 @@
 # Source the functions that will be used to build the targets in p3_targets_list
-
+source("3_harmonize/src/format_columns.R")
 
 p3_targets_list <- list(
   
+  # All columns in p2_wqp_data_aoi are of class character. Coerce select columns
+  # back to numeric, and save an output file that contains any entries that could 
+  # not be parsed as numeric. The default option is to format "ResultMeasureValue" 
+  # and "DetectionQuantitationLimitMeasure.MeasureValue" to numeric, but additional
+  # variables can be added using the `vars_to_numeric` argument in format_columns().
+  # The default option is to retain all columns, but undesired variables can also be 
+  # dropped from the WQP dataset using the optional `drop_vars` argument. 
+  tar_target(
+    p3_wqp_data_aoi_formatted,
+    format_columns(p2_wqp_data_aoi, save_dir = "3_harmonize/out")
+  )
 
 )

--- a/3_harmonize.R
+++ b/3_harmonize.R
@@ -1,0 +1,7 @@
+# Source the functions that will be used to build the targets in p3_targets_list
+
+
+p3_targets_list <- list(
+  
+
+)

--- a/3_harmonize.R
+++ b/3_harmonize.R
@@ -4,17 +4,15 @@ source("3_harmonize/src/format_columns.R")
 p3_targets_list <- list(
   
   # All columns in p2_wqp_data_aoi are of class character. Coerce select columns
-  # back to numeric, and save an output file that contains any entries that could 
-  # not be parsed as numeric. The default option is to format "ResultMeasureValue" 
-  # and "DetectionQuantitationLimitMeasure.MeasureValue" to numeric, but additional
+  # back to numeric, but first retain original entries in new columns ending in 
+  # "_original". The default option is to format "ResultMeasureValue" and 
+  # "DetectionQuantitationLimitMeasure.MeasureValue" to numeric, but additional
   # variables can be added using the `vars_to_numeric` argument in format_columns().
-  # For any columns parsed to numeric, the original entries are retained in columns
-  # ending in "_original." By default, format_columns() will retain all columns, 
-  # but undesired variables can also be dropped from the WQP dataset using the 
-  # optional `drop_vars` argument. 
+  # By default, format_columns() will retain all columns, but undesired variables 
+  # can also be dropped from the WQP dataset using the optional `drop_vars` argument. 
   tar_target(
     p3_wqp_data_aoi_formatted,
-    format_columns(p2_wqp_data_aoi, save_dir = "3_harmonize/out")
+    format_columns(p2_wqp_data_aoi)
   )
 
 )

--- a/3_harmonize/src/format_columns.R
+++ b/3_harmonize/src/format_columns.R
@@ -1,0 +1,130 @@
+#' @title Format WQP data columns, including to convert some columns of class
+#' character back to numeric
+#' 
+#' @description
+#' Function to format WQP data columns, including to convert some columns of
+#' class character back to numeric. This function also presents the option 
+#' to drop undesired columns from the formatted data frame.
+#' 
+#' @param wqp_data data frame containing the data downloaded from the WQP, 
+#' where each row represents a unique data record.
+#' @param save_dir character string indicating the directory where an output
+#' file should be saved. The output file is intended to inform the user of any
+#' WQP entries in columns `vars_to_numeric` that were not able to be parsed to
+#' numeric values and so were replaced with NA.
+#' @param vars_to_numeric character string indicating which column(s) should be 
+#' coerced to class numeric. Default includes two columns: `ResultMeasureValue` 
+#' and `DetectionQuantitationLimitMeasure.MeasureValue`.
+#' @param drop_vars optional; character string indicating any undesired
+#' variables that should be dropped from the WQP dataset. Default is to retain 
+#' all variables. Note that certain variables are used in downstream 
+#' harmonization steps and should not be omitted from the dataset. If 
+#' `drop_vars` contains a variable considered important for harmonization, an
+#' error message will prompt the user to remove that variable from `drop_vars`.
+#' 
+#' @returns
+#' Returns a formatted data frame containing data downloaded from the Water 
+#' Quality Portal, where each row represents a unique data record.
+#' 
+format_columns <- function(wqp_data, 
+                           save_dir,
+                           vars_to_numeric = c('ResultMeasureValue',
+                                               'DetectionQuantitationLimitMeasure.MeasureValue'),
+                           drop_vars = NULL){
+  
+  # Some vars should not be dropped because they are needed in downstream 
+  # harmonization steps.
+  keep_vars <- c('CharacteristicName', 'ResultMeasureValue',
+                 'DetectionQuantitationLimitMeasure.MeasureValue',
+                 'ResultDetectionConditionText', 'ResultCommentText,',
+                 'ResultMeasure.MeasureUnitCode')
+  if(any(drop_vars %in% keep_vars)){
+    drop_vars_to_keep <- keep_vars[keep_vars %in% drop_vars]
+    stop(sprintf(paste0("Certain variables cannot be dropped. Please ",
+                        "remove the following variables from drop_vars: \n%s\n"),
+                 drop_vars_to_keep))
+  }
+ 
+  # Coerce variables to numeric, but first, retain original values in a new column
+  wqp_data_out <- wqp_data %>%
+    mutate(across(all_of(vars_to_numeric), ~., .names = "{col}_original"),
+           across(all_of(vars_to_numeric), as.numeric)) %>%
+    # format column order so that "original" cols are located next to formatted 
+    # vars_to_numeric cols
+    select(c("OrganizationIdentifier", "MonitoringLocationIdentifier",
+             "ActivityStartDate", "ActivityStartTime.Time",
+             "ActivityStartTime.TimeZoneCode", "CharacteristicName"), 
+           any_of(ends_with("_original")),
+           any_of(vars_to_numeric),
+           everything()) %>%
+    # suppress warnings including "NAs introduced by coercion" that will
+    # appear if values within a column in `vars_to_numeric` contain text
+    # and so cannot be parsed to a numeric value.
+    suppressWarnings() %>%
+    # drop any undesired columns 
+    select(-c(any_of(drop_vars)))
+    
+  # Save a file containing which values were replaced with NA when column
+  # was converted from character to numeric  
+  save_NA_vals(wqp_data, save_dir, vars_to_numeric)
+  
+  return(wqp_data_out)
+}
+
+
+#' @title Record values that have been replaced with NA
+#' 
+#' @description
+#' Function to save an output file that contains any values that were replaced
+#' with NA when a column was converted from class character to class numeric. 
+#' Values were replaced with NA if the original entry could not be parsed as 
+#' a numeric value.
+#' 
+#' @param wqp_data data frame containing the data downloaded from the WQP, 
+#' where each row represents a unique data record.
+#' @param save_dir character string indicating the directory where an output
+#' file should be saved. The output file is intended to inform the user of any
+#' WQP entries in columns `vars_to_numeric` that were not able to be parsed to
+#' numeric values and so were replaced with NA.
+#' @param vars_to_numeric character string indicating which column(s) should be 
+#' coerced to class numeric. 
+#' 
+#' @returns 
+#' Returns a character string indicating the file path of the saved output file.
+#' The saved .txt file includes a section for each column in `vars_to_numeric` 
+#' that contains the original WQP entries for that column that were replaced with 
+#' NA when the column was converted from class character to class numeric.
+#' 
+save_NA_vals <- function(wqp_data, save_dir, vars_to_numeric){
+
+  # Find any values from the original columns that were replaced with NA
+  values_replaced_with_na <- lapply(vars_to_numeric, function(x){
+    
+    vars_vals_na <- wqp_data %>%
+      filter(!is.na(.data[[x]]),
+             is.na(as.numeric(.data[[x]]))) %>%
+      suppressWarnings() %>%
+      pull(.data[[x]]) %>% 
+      unique()
+    
+    if(length(vars_vals_na) > 0){
+      out <- sprintf(paste0("The following entries for ", x, " cannot be ",
+                            "parsed as numeric and will be converted to ",
+                            "NA:\n\n%s\n"),
+                     paste(unique(vars_vals_na), collapse = "\n"))
+    } else {
+      out <- paste0("Good news! All entries for ", x, " could be parsed as ",
+                    "numeric. \n")
+    }
+    return(out)
+  })
+
+  # Save a file containing which values were replaced with NA when column
+  # was converted from character to numeric
+  out_file <- paste0(save_dir,"/WQP_entries_replaced_with_NA.txt")
+  writeLines(paste(unlist(lapply(values_replaced_with_na, paste, collapse = " "))), 
+             out_file)
+  
+  return(out_file)
+}
+

--- a/3_harmonize/src/format_columns.R
+++ b/3_harmonize/src/format_columns.R
@@ -8,13 +8,11 @@
 #' 
 #' @param wqp_data data frame containing the data downloaded from the WQP, 
 #' where each row represents a unique data record.
-#' @param save_dir character string indicating the directory where an output
-#' file should be saved. The output file is intended to inform the user of any
-#' WQP entries in columns `vars_to_numeric` that were not able to be parsed to
-#' numeric values and so were replaced with NA.
 #' @param vars_to_numeric character string indicating which column(s) should be 
 #' coerced to class numeric. Default includes two columns: `ResultMeasureValue` 
-#' and `DetectionQuantitationLimitMeasure.MeasureValue`.
+#' and `DetectionQuantitationLimitMeasure.MeasureValue`. Note that for all
+#' columns coerced to numeric, the original entries will be retained in new
+#' columns ending in "_original."
 #' @param drop_vars optional; character string indicating any undesired
 #' variables that should be dropped from the WQP dataset. Default is to retain 
 #' all variables. Note that certain variables are used in downstream 
@@ -27,7 +25,6 @@
 #' Quality Portal, where each row represents a unique data record.
 #' 
 format_columns <- function(wqp_data, 
-                           save_dir,
                            vars_to_numeric = c('ResultMeasureValue',
                                                'DetectionQuantitationLimitMeasure.MeasureValue'),
                            drop_vars = NULL){
@@ -63,68 +60,8 @@ format_columns <- function(wqp_data,
     suppressWarnings() %>%
     # drop any undesired columns 
     select(-c(any_of(drop_vars)))
-    
-  # Save a file containing which values were replaced with NA when column
-  # was converted from character to numeric  
-  save_NA_vals(wqp_data, save_dir, vars_to_numeric)
   
   return(wqp_data_out)
 }
 
-
-#' @title Record values that have been replaced with NA
-#' 
-#' @description
-#' Function to save an output file that contains any values that were replaced
-#' with NA when a column was converted from class character to class numeric. 
-#' Values were replaced with NA if the original entry could not be parsed as 
-#' a numeric value.
-#' 
-#' @param wqp_data data frame containing the data downloaded from the WQP, 
-#' where each row represents a unique data record.
-#' @param save_dir character string indicating the directory where an output
-#' file should be saved. The output file is intended to inform the user of any
-#' WQP entries in columns `vars_to_numeric` that were not able to be parsed to
-#' numeric values and so were replaced with NA.
-#' @param vars_to_numeric character string indicating which column(s) should be 
-#' coerced to class numeric. 
-#' 
-#' @returns 
-#' Returns a character string indicating the file path of the saved output file.
-#' The saved .txt file includes a section for each column in `vars_to_numeric` 
-#' that contains the original WQP entries for that column that were replaced with 
-#' NA when the column was converted from class character to class numeric.
-#' 
-save_NA_vals <- function(wqp_data, save_dir, vars_to_numeric){
-
-  # Find any values from the original columns that were replaced with NA
-  values_replaced_with_na <- lapply(vars_to_numeric, function(x){
-    
-    vars_vals_na <- wqp_data %>%
-      filter(!is.na(.data[[x]]),
-             is.na(as.numeric(.data[[x]]))) %>%
-      suppressWarnings() %>%
-      pull(.data[[x]]) %>% 
-      unique()
-    
-    if(length(vars_vals_na) > 0){
-      out <- sprintf(paste0("The following entries for ", x, " cannot be ",
-                            "parsed as numeric and will be converted to ",
-                            "NA:\n\n%s\n"),
-                     paste(unique(vars_vals_na), collapse = "\n"))
-    } else {
-      out <- paste0("Good news! All entries for ", x, " could be parsed as ",
-                    "numeric. \n")
-    }
-    return(out)
-  })
-
-  # Save a file containing which values were replaced with NA when column
-  # was converted from character to numeric
-  out_file <- paste0(save_dir,"/WQP_entries_replaced_with_NA.txt")
-  writeLines(paste(unlist(lapply(values_replaced_with_na, paste, collapse = " "))), 
-             out_file)
-  
-  return(out_file)
-}
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ We currently include a few select data cleaning steps in the `3_harmonize` phase
 The first harmonization step is to format columns, which includes converting select columns to class `numeric` and optionally, dropping undesired columns from the downloaded dataset. WQP variables intended to represent numeric values will occasionally contain non-numeric values (e.g. when `"*Non-detect"` appears in column `ResultMeasureValue`). The original entries are retained in a separate column for reference and non-numeric values are replaced with `NA`. If you want to see the unexpected, non-numeric values that are converted to `NA` for columns that we formatted as numeric, you can quickly do that after the pipeline has run using code like the example using `ResultMeasureValue` below:  
 
 ```r
+library(dplyr)
 tar_load(p3_wqp_data_aoi_formatted)
 p3_wqp_data_aoi_formatted %>%
   dplyr::filter(is.na(ResultMeasureValue),

--- a/_targets.R
+++ b/_targets.R
@@ -6,6 +6,7 @@ tar_option_set(packages = c('tidyverse', 'lubridate', 'dataRetrieval',
 
 source("1_inventory.R")
 source("2_download.R")
+source("3_harmonize.R")
 
 # Define the temporal extent of our data pull
 # set start_date or end_date to "" to query the earliest or latest available date
@@ -36,6 +37,6 @@ wqp_args <- list(sampleMedia = c("Water","water"),
                  startDateHi = end_date)
 
 # Return the complete list of targets
-c(p1_targets_list, p2_targets_list)
+c(p1_targets_list, p2_targets_list, p3_targets_list)
 
 


### PR DESCRIPTION
This PR initializes the files for the `3_harmonize` phase of the pipeline and adds a harmonization step to format the columns in the downloaded dataset. 

In #47, we found that some entries in otherwise numeric columns caused problems when merging the data frames from different branches, and so we coerced all columns to character in `fetch_wqp_data()`. The new function `format_columns()` takes a vector of strings representing which columns should be coerced back to numeric (the default is to just consider two columns where I've seen problematic entries before: `ResultMeasureValue` and `DetectionQuantitationLimitMeasure.MeasureValue`). Any values in these columns that cannot be parsed as numeric values will be converted to `NA`. The code here replaces the values in `ResultMeasureValue` but before doing so, creates a duplicate column called `ResultMeasureValue_original` to satisfy some users' preference to retain the original entries. 

`format_columns()` includes a call to a second function, `save_NA_vals()` that outputs a .txt file indicating what the problematic entries were. This feature is meant to give users more information and some peace of mind for which values we're converting to `NA`. These steps are all included in the target `p3_wqp_data_aoi_formatted` but I'm not sure if that is ideal and would appreciate your feedback there (i.e. _do you think the output file should be its own target?_).

Note that our 'usual' pipeline parameters don't contain any oddball entries in `ResultMeasureValue`. If you want to see what the output file looks like in a case where original values are replaced with `NA`, swap out parts of `_targets.R` for the following from #47:

```r
# heavy temperature site -87.98712 44.64798; WIDNR_WQX-10039610
coords_lon <- c(-90.333, -87.8, -89)
coords_lat <- c(42.547, 45.029, 35.880)

# Specify arguments to WQP queries
# see https://www.waterqualitydata.us/webservices_documentation for more information 
wqp_args <- list(sampleMedia = c("Water","water"),
                 siteType = "Lake, Reservoir, Impoundment",
                 # return sites with at least one data record
                 minresults = 1, 
                 startDateLo = start_date,
                 startDateHi = end_date)
```

If we load the formatted data, we can look for a few of the problematic values and compare the original WQP entries with our updated column:

```r
> tar_load(p3_wqp_data_aoi_formatted)
> p3_wqp_data_aoi_formatted %>% 
+     select(ResultMeasureValue_original, ResultMeasureValue) %>% 
+     filter(ResultMeasureValue_original %in% c("11..2","UNKNOWN","27.4 C"))
  ResultMeasureValue_original ResultMeasureValue
1                       11..2                 NA
2                     UNKNOWN                 NA
3                      27.4 C                 NA
> 
```



The pipeline using the above arguments takes ~10 minutes to build for me, most of which was fetching the data:

```r
> tar_meta() %>% filter(name == "p2_wqp_data_aoi") %>% pull(seconds) 
[1] 480.9
```

Closes #53 
