### PR TITLE
Harmonize sets of characteristic names

### DIFF
--- a/1_inventory.R
+++ b/1_inventory.R
@@ -15,16 +15,23 @@ p1_targets_list <- list(
     format = "file"
   ),
   
-  # Load yml file containing common parameters groups and WQP characteristic names
+  # Load yml file containing common parameter groups and WQP characteristic names
   tar_target(
     p1_wqp_params,
     yaml::read_yaml(p1_wqp_params_yml) 
   ),
   
+  # Format a table that indicates how various WQP characteristic names map onto 
+  # more commonly-used parameter names
+  tar_target(
+    p1_char_names_crosswalk,
+    crosswalk_characteristics(p1_wqp_params)
+  ),
+  
   # Get a vector of WQP characteristic names to match parameter groups of interest
   tar_target(
     p1_char_names,
-    filter_characteristics(p1_wqp_params, param_groups_select)
+    filter_characteristics(p1_char_names_crosswalk, param_groups_select)
   ),
   
   # Save output file(s) containing WQP characteristic names that are similar to the

--- a/1_inventory/src/check_characteristics.R
+++ b/1_inventory/src/check_characteristics.R
@@ -1,3 +1,31 @@
+#' @title Create parameter-characteristics crosswalk table
+#' 
+#' @description 
+#' Function to create a crosswalk table that maps characteristic names onto
+#' more commonly-used water quality parameter names. 
+
+#' @param wqp_params list object where each element of the list is a named vector.
+#' The vectors correspond with a parameter group and contain character string(s)
+#' representing known WQP characteristic names associated with each parameter.
+#' 
+#' @returns 
+#' Returns a data frame containing a row for each unique characteristic name.
+#' Columns represent the characteristic name and its corresponding parameter 
+#' name.
+#' 
+crosswalk_characteristics <- function(wqp_params){
+  
+  params_df <- lapply(names(wqp_params), function(x){
+    params <- data.frame(char_name = wqp_params[[x]],
+                         parameter = x) 
+  }) %>%
+    bind_rows()
+  
+  return(params_df)
+  
+}
+
+
 #' @title Read valid WQP characteristic names
 #' 
 #' @description 
@@ -58,12 +86,12 @@ check_valid_characteristics <- function(char_names) {
 #' 
 #' @description
 #' Function to filter WQP parameters and associated characteristic names from a 
-#' general configuration file. Characteristic names associated with the requested 
-#' parameter groups of interest will be included in the data pull.  
+#' characteristics-to-parameter crosswalk table. Characteristic names associated 
+#' with the requested parameter groups of interest will be included in the data pull.  
 #' 
-#' @param wqp_params list object where each element of the list is a named vector.
-#' The vectors correspond with a parameter group and contain character string(s)
-#' representing known WQP characteristic names associated with each parameter. 
+#' @param char_names_crosswalk data frame containing columns "char_name" and 
+#' "parameter". The column "char_name" contains character strings representing 
+#' known WQP characteristic names associated with each parameter.
 #' @param param_groups_select character string indicating which parameter groups 
 #' to request in the WQP data pull. Parameter strings should match the vector
 #' names in `wqp_params`.
@@ -75,14 +103,16 @@ check_valid_characteristics <- function(char_names) {
 #' characteristics do not exist in the WQP.
 #' 
 #' @examples 
-#' params <- list(pH = c("PH", "pH", "pH, lab"))
-#' param_group_select <- "pH"
-#' filter_characteristics(params, param_group_select)
+#' params <- data.frame(char_name = c("PH", "pH", "pH, lab"),
+#'                      parameter = rep("pH", 3))
+#' filter_characteristics(params, "pH")
 #' 
-filter_characteristics <- function(wqp_params, param_groups_select){
+filter_characteristics <- function(char_names_crosswalk, param_groups_select){
   
   # Create character string containing desired characteristic names
-  characteristics_select <- as.character(unlist(wqp_params[param_groups_select]))
+  characteristics_select <- char_names_crosswalk %>%
+    filter(parameter %in% param_groups_select) %>%
+    pull(char_name)
   
   # Return desired characteristic names that represent valid WQP characteristics
   characteristics_in_wqp <- characteristics_select[check_valid_characteristics(characteristics_select)]

--- a/3_harmonize.R
+++ b/3_harmonize.R
@@ -1,5 +1,6 @@
 # Source the functions that will be used to build the targets in p3_targets_list
 source("3_harmonize/src/format_columns.R")
+source("3_harmonize/src/clean_wqp_data.R")
 
 p3_targets_list <- list(
   
@@ -13,6 +14,12 @@ p3_targets_list <- list(
   tar_target(
     p3_wqp_data_aoi_formatted,
     format_columns(p2_wqp_data_aoi)
+  ),
+  
+  # Harmonize WQP data
+  tar_target(
+    p3_wqp_data_aoi_clean,
+    clean_wqp_data(p3_wqp_data_aoi_formatted, p1_wqp_params)
   )
 
 )

--- a/3_harmonize.R
+++ b/3_harmonize.R
@@ -19,7 +19,7 @@ p3_targets_list <- list(
   # Harmonize WQP data
   tar_target(
     p3_wqp_data_aoi_clean,
-    clean_wqp_data(p3_wqp_data_aoi_formatted, p1_wqp_params)
+    clean_wqp_data(p3_wqp_data_aoi_formatted, p1_char_names_crosswalk)
   )
 
 )

--- a/3_harmonize/src/clean_wqp_data.R
+++ b/3_harmonize/src/clean_wqp_data.R
@@ -5,8 +5,9 @@
 #' in this function are steps to unite diverse characteristic names by assigning
 #' them to more commonly-used water quality parameter names. 
 #' 
-#' @param wqp_data data frame containing the data downloaded from the WQP, 
-#' where each row represents a unique data record.
+#' @param char_names_crosswalk data frame containing columns "char_name" and 
+#' "parameter". The column "char_name" contains character strings representing 
+#' known WQP characteristic names associated with each parameter.
 #' @param wqp_params list object where each element of the list is a named vector.
 #' The vectors correspond with a parameter group and contain character string(s)
 #' representing known WQP characteristic names associated with each parameter. 
@@ -15,21 +16,13 @@
 #' Returns a formatted and harmonized data frame containing data downloaded from 
 #' the Water Quality Portal, where each row represents a unique data record.
 #' 
-clean_wqp_data <- function(wqp_data, wqp_params){
-  
-  # Before we clean any data, format a table that indicates how various 
-  # characteristic names map onto more commonly-used parameter names
-  params_df <- lapply(names(wqp_params), function(x){
-    params <- data.frame(char_name = wqp_params[[x]],
-                         parameter = x) 
-  }) %>%
-    bind_rows()
-  
+clean_wqp_data <- function(wqp_data, char_names_crosswalk){
+
   # Clean data and assign flags if applicable
   wqp_data_clean <- wqp_data %>%
     # harmonize characteristic names by assigning a common parameter name
-    # to the groups of characteristics supplied in `wqp_params`.
-    left_join(y = params_df, by = c("CharacteristicName" = "char_name"))
+    # to the groups of characteristics supplied in `char_names_crosswalk`.
+    left_join(y = char_names_crosswalk, by = c("CharacteristicName" = "char_name"))
   
   return(wqp_data_clean)
   

--- a/3_harmonize/src/clean_wqp_data.R
+++ b/3_harmonize/src/clean_wqp_data.R
@@ -1,0 +1,38 @@
+#' @title Clean WQP data
+#' 
+#' @description 
+#' Function to harmonize WQP data in preparation for further analysis. Included
+#' in this function are steps to unite diverse characteristic names by assigning
+#' them to more commonly-used water quality parameter names. 
+#' 
+#' @param wqp_data data frame containing the data downloaded from the WQP, 
+#' where each row represents a unique data record.
+#' @param wqp_params list object where each element of the list is a named vector.
+#' The vectors correspond with a parameter group and contain character string(s)
+#' representing known WQP characteristic names associated with each parameter. 
+#' 
+#' @returns 
+#' Returns a formatted and harmonized data frame containing data downloaded from 
+#' the Water Quality Portal, where each row represents a unique data record.
+#' 
+clean_wqp_data <- function(wqp_data, wqp_params){
+  
+  # Before we clean any data, format a table that indicates how various 
+  # characteristic names map onto more commonly-used parameter names
+  params_df <- lapply(names(wqp_params), function(x){
+    params <- data.frame(char_name = wqp_params[[x]],
+                         parameter = x) 
+  }) %>%
+    bind_rows()
+  
+  # Clean data and assign flags if applicable
+  wqp_data_clean <- wqp_data %>%
+    # harmonize characteristic names by assigning a common parameter name
+    # to the groups of characteristics supplied in `wqp_params`.
+    left_join(y = params_df, by = c("CharacteristicName" = "char_name"))
+  
+  return(wqp_data_clean)
+  
+  
+}
+

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ We could also use existing watershed boundaries or another polygon from an exter
 ```
 
 ### Changing the parameter list
-This workflow comes with a configuration file containing common water quality parameter groups and associated WQP characteristic names ("1_inventory/cfg_wqp_codes.yml"). This configuration file is meant to provide a starting place for an analysis and does not represent a definitive list of characteristic names. The yml file can be edited to omit certain characteristic names or include others, however, it's recommended to leave the top-level parameter names as is to avoid downstream impacts to the code within the "3_harmonize" phase of the pipeline.
+This workflow comes with a configuration file containing common water quality parameter groups and associated WQP characteristic names ("1_inventory/cfg_wqp_codes.yml"). This configuration file is meant to provide a starting place for an analysis and does not represent a definitive list of characteristic names. The yml file can be edited to omit certain characteristic names and include others, to change top-level parameter names, or to customize parameter groupings. 
 
 ### Changing the date range
 Customize the temporal extent of the WQP data pull by editing the variables `start_date` and `end_date` in `_targets.R`. Queries can accept `start_date` and `end_date` in `"YYYY-MM-DD"` format, or can be set to `""` to request the earliest or latest available dates, respectively. 

--- a/_targets.R
+++ b/_targets.R
@@ -15,11 +15,12 @@ end_date <- "2020-12-31"
 
 # Define which parameter groups (and CharacteristicNames) to return from WQP. 
 # Different options for parameter groups are represented in the first level of 
-# 1_inventory/cfg/wqp_codes.yml. This yml file is meant to provide a starting
-# place for an analysis and does not represent a definitive list of characteristic
-# names. Which characteristic names to include for any given parameter group may
+# 1_inventory/cfg/wqp_codes.yml. This yml file is meant to provide a starting 
+# place for an analysis and does not represent a definitive list of characteristic 
+# names. Which characteristic names to include for any given parameter group may 
 # change depending on the user or application, so the yml file can be edited to 
-# omit characteristic names or include others.
+# omit characteristic names or include others, to change top-level parameter names,
+# or to customize parameter groupings. 
 param_groups_select <- c('temperature','conductivity')
 
 # Specify coordinates that define the spatial area of interest


### PR DESCRIPTION
This PR adds a function called `clean_wqp_data()` to the `3_harmonize` phase of the pipeline. For now the function includes a step to harmonize sets of characteristic names under the more commonly-used water quality parameter names included in the top-level of the `wqp_codes.yml` config file. I envision adding a few more data cleaning steps to this function in future PR's. 

This step allows data records to be filtered down to parameter groups of interest more readily using the new column `parameter`. Here's what I see as output given the "normal" input args to this pipeline: 

```r
> tar_load(p3_wqp_data_aoi_clean)
> p3_wqp_data_aoi_clean %>% 
+   group_by(parameter, CharacteristicName) %>%
+   summarize(n = n())
`summarise()` has grouped output by 'parameter'. You can override using the `.groups` argument.
# A tibble: 4 x 3
# Groups:   parameter [2]
  parameter    CharacteristicName                                  n
  <chr>        <chr>                                           <int>
1 conductivity Conductivity                                        7
2 conductivity Specific conductance                            11438
3 conductivity Specific Conductance, Calculated/Measured Ratio    48
4 temperature  Temperature, water                               8773
>

```