### PR TITLE
Modify how we name download groups

### DIFF
--- a/2_download/src/fetch_wqp_data.R
+++ b/2_download/src/fetch_wqp_data.R
@@ -99,8 +99,7 @@ add_download_groups <- function(sitecounts_df, max_sites = 500, max_results = 25
         arrange(desc(results_count)) %>%
         mutate(task_num = MESS::cumsumbinning(x = results_count, 
                                               threshold = max_results, 
-                                              maxgroupsize = max_sites),
-               download_grp = paste0(grid_id,"_",task_num))
+                                              maxgroupsize = max_sites))
     }) %>%
     mutate(pull_by_id = TRUE)
   
@@ -116,6 +115,10 @@ add_download_groups <- function(sitecounts_df, max_sites = 500, max_results = 25
   # format columns
   sitecounts_grouped_out <- sitecounts_grouped_good_ids %>%
     bind_rows(sitecounts_grouped_bad_ids) %>%
+    # Ensure the groups are ordered correctly by prepending a dynamic number of 0s
+    # before the task number based on the maximum number of tasks.
+    mutate(download_grp = sprintf(paste0("%s_%0", nchar(max(task_num)), "d"), 
+                                  grid_id, task_num)) %>% 
     arrange(download_grp) %>%
     select(site_id, lat, lon, datum, results_count, download_grp, pull_by_id) 
   

--- a/2_download/src/fetch_wqp_data.R
+++ b/2_download/src/fetch_wqp_data.R
@@ -107,7 +107,6 @@ add_download_groups <- function(sitecounts_df, max_sites = 500, max_results = 25
   sitecounts_grouped_bad_ids <- sitecounts_bad_ids %>%
     group_by(site_id) %>%
     mutate(task_num = max(sitecounts_grouped_good_ids$task_num) + cur_group_id(),
-           download_grp = paste0(grid_id,"_",task_num),
            pull_by_id = FALSE) %>%
     ungroup()
   


### PR DESCRIPTION
This PR implements the suggested change in #72 that @lindsayplatt implemented in the (internal) national chl-a pipeline. This change ensures the groups are ordered as we'd expect 🎉

In our example pipeline we don't see much difference from this change, though, since there aren't enough samples to push us past any `task_num` > 1:

```r
> tar_load(p2_site_counts_grouped)
> unique(p2_site_counts_grouped$download_grp)
[1] "11573_1" "11752_1" "11753_1"
>
```