### PR TITLE
Flag duplicated records

### DIFF
--- a/3_harmonize/src/clean_wqp_data.R
+++ b/3_harmonize/src/clean_wqp_data.R
@@ -6,12 +6,11 @@
 #' them to more commonly-used water quality parameter names, and to flag missing
 #' records as well as duplicate records.
 #' 
+#' @param wqp_data data frame containing the data downloaded from the WQP, 
+#' where each row represents a unique data record.
 #' @param char_names_crosswalk data frame containing columns "char_name" and 
 #' "parameter". The column "char_name" contains character strings representing 
 #' known WQP characteristic names associated with each parameter.
-#' @param wqp_params list object where each element of the list is a named vector.
-#' The vectors correspond with a parameter group and contain character string(s)
-#' representing known WQP characteristic names associated with each parameter. 
 #' @param commenttext_missing character string(s) indicating which strings from
 #' the WQP column "ResultCommentText" correspond with missing result values. By 
 #' default, the column "ResultCommentText" will be searched for the following 

--- a/3_harmonize/src/clean_wqp_data.R
+++ b/3_harmonize/src/clean_wqp_data.R
@@ -90,12 +90,11 @@ clean_wqp_data <- function(wqp_data, char_names_crosswalk,
 flag_missing_results <- function(wqp_data, commenttext_missing){
   
   wqp_data_out <- wqp_data %>%
-    mutate(flag_missing_result = case_when(
-      is.na(ResultMeasureValue) & is.na(DetectionQuantitationLimitMeasure.MeasureValue) ~ TRUE,
-      grepl("not reported", ResultDetectionConditionText, ignore.case = TRUE) ~ TRUE,
-      grepl(paste(commenttext_missing, collapse = "|"), ResultCommentText, ignore.case = TRUE) ~ TRUE,
-      TRUE ~ FALSE
-    ))
+    mutate(flag_missing_result = 
+             ( is.na(ResultMeasureValue) & is.na(DetectionQuantitationLimitMeasure.MeasureValue) ) |
+             grepl("not reported", ResultDetectionConditionText, ignore.case = TRUE) |
+             grepl(paste(commenttext_missing, collapse = "|"), ResultCommentText, ignore.case = TRUE)
+    )
   
   return(wqp_data_out)
   

--- a/3_harmonize/src/clean_wqp_data.R
+++ b/3_harmonize/src/clean_wqp_data.R
@@ -24,6 +24,8 @@
 #' organization, site id, date, time, characteristic name, and sample fraction. 
 #' However, these options can be customized by passing a vector of column names 
 #' to the argument `duplicate_definition`.
+#' @param remove_duplicated_rows logical; should duplicated records be omitted
+#' from the cleaned dataset? Defaults to TRUE. 
 #' 
 #' @returns 
 #' Returns a formatted and harmonized data frame containing data downloaded from 
@@ -38,7 +40,8 @@ clean_wqp_data <- function(wqp_data, char_names_crosswalk,
                                                     'ActivityStartDate', 
                                                     'ActivityStartTime.Time',
                                                     'CharacteristicName', 
-                                                    'ResultSampleFractionText')){
+                                                    'ResultSampleFractionText'),
+                           remove_duplicated_rows = TRUE){
 
   # Clean data and assign flags if applicable
   wqp_data_clean <- wqp_data %>%
@@ -49,11 +52,18 @@ clean_wqp_data <- function(wqp_data, char_names_crosswalk,
     flag_missing_results(., commenttext_missing) %>%
     # flag duplicate records
     flag_duplicates(., duplicate_definition) %>%
-    remove_duplicates(., duplicate_definition)
+    {if(remove_duplicated_rows){
+      remove_duplicates(., duplicate_definition)
+    } else {.}
+    }
   
+  # Inform the user what we found for duplicated rows
+  if(remove_duplicated_rows){
+    message(sprintf(paste0("Removed %s duplicated records."), 
+                    nrow(wqp_data) - nrow(wqp_data_clean)))
+  }
   
   return(wqp_data_clean)
-  
   
 }
 

--- a/3_harmonize/src/clean_wqp_data.R
+++ b/3_harmonize/src/clean_wqp_data.R
@@ -125,7 +125,7 @@ flag_duplicates <- function(wqp_data, duplicate_definition){
   wqp_data_out <- wqp_data %>%
     group_by(across(all_of(duplicate_definition))) %>% 
     mutate(n_duplicated = n(),
-           flag_duplicated_row = if_else(n_duplicated > 1, TRUE, FALSE)) %>% 
+           flag_duplicated_row = n_duplicated > 1) %>% 
     ungroup()
   
   return(wqp_data_out)
@@ -157,9 +157,7 @@ remove_duplicates <- function(wqp_data, duplicate_definition){
     # To help resolve duplicates, randomly select the first record
     # from each duplicated set and flag all others for exclusion.
     mutate(dup_number = seq(n_duplicated),
-           flag_duplicate_drop_random = if_else(n_duplicated > 1 & 
-                                                  dup_number != 1, 
-                                                TRUE, FALSE)) %>%
+           flag_duplicate_drop_random = n_duplicated > 1 & dup_number != 1) %>%
     filter(flag_duplicate_drop_random == FALSE) %>%
     ungroup() %>%
     select(-c(n_duplicated, dup_number, flag_duplicate_drop_random))

--- a/3_harmonize/src/clean_wqp_data.R
+++ b/3_harmonize/src/clean_wqp_data.R
@@ -15,7 +15,8 @@
 #' the WQP column "ResultCommentText" correspond with missing result values. By 
 #' default, the column "ResultCommentText" will be searched for the following 
 #' strings: "analysis lost", "not analyzed", "not recorded", "not collected", 
-#' and "no measurement taken", but other values may be added as well. 
+#' and "no measurement taken", but other values may be added by passing in a new
+#' vector with all values to be treated as missing.  
 #' @param duplicate_definition character string(s) indicating which columns are
 #' used to identify a duplicate record. Duplicate records are defined as those 
 #' that share the same value for each column within `duplicate_definition`. By 
@@ -72,7 +73,7 @@ clean_wqp_data <- function(wqp_data, char_names_crosswalk,
 #' easier to drop all others from the dataset. 
 #' 
 #' @param wqp_data data frame containing the data downloaded from the WQP, 
-#' where each row represents a unique data record.
+#' where each row represents a data record.
 #' @param duplicate_definition character string(s) indicating which columns are
 #' used to identify a duplicate record. Duplicate records are defined as those 
 #' that share the same value for each column within `duplicate_definition`.

--- a/3_harmonize/src/clean_wqp_data.R
+++ b/3_harmonize/src/clean_wqp_data.R
@@ -3,7 +3,8 @@
 #' @description 
 #' Function to harmonize WQP data in preparation for further analysis. Included
 #' in this function are steps to unite diverse characteristic names by assigning
-#' them to more commonly-used water quality parameter names. 
+#' them to more commonly-used water quality parameter names, and to flag missing
+#' records as well as duplicate records.
 #' 
 #' @param char_names_crosswalk data frame containing columns "char_name" and 
 #' "parameter". The column "char_name" contains character strings representing 
@@ -11,18 +12,35 @@
 #' @param wqp_params list object where each element of the list is a named vector.
 #' The vectors correspond with a parameter group and contain character string(s)
 #' representing known WQP characteristic names associated with each parameter. 
+#' @param commenttext_missing character string(s) indicating which strings from
+#' the WQP column "ResultCommentText" correspond with missing result values. By 
+#' default, the column "ResultCommentText" will be searched for the following 
+#' strings: "analysis lost", "not analyzed", "not recorded", "not collected", 
+#' and "no measurement taken", but other values may be added as well. 
 #' 
 #' @returns 
 #' Returns a formatted and harmonized data frame containing data downloaded from 
 #' the Water Quality Portal, where each row represents a unique data record.
 #' 
-clean_wqp_data <- function(wqp_data, char_names_crosswalk){
+clean_wqp_data <- function(wqp_data, char_names_crosswalk,
+                           commenttext_missing = c('analysis lost', 'not analyzed', 
+                                                   'not recorded', 'not collected', 
+                                                   'no measurement taken')){
 
   # Clean data and assign flags if applicable
   wqp_data_clean <- wqp_data %>%
     # harmonize characteristic names by assigning a common parameter name
     # to the groups of characteristics supplied in `char_names_crosswalk`.
-    left_join(y = char_names_crosswalk, by = c("CharacteristicName" = "char_name"))
+    left_join(y = char_names_crosswalk, by = c("CharacteristicName" = "char_name")) %>%
+    # flag true missing results, i.e. when result measure value and detection
+    # limit value are both NA, when "not reported" is found in the column
+    # "ResultDetectionConditionText", or when any of the strings from
+    # `commenttext_missing` are found in the column "ResultCommentText".
+    mutate(flag_missing_result = case_when(
+      is.na(ResultMeasureValue) & is.na(DetectionQuantitationLimitMeasure.MeasureValue) ~ TRUE,
+      grepl("not reported", ResultDetectionConditionText, ignore.case = TRUE) ~ TRUE,
+      grepl(paste(commenttext_missing, collapse = "|"), ResultCommentText, ignore.case = TRUE) ~ TRUE
+    )) 
   
   return(wqp_data_clean)
   

--- a/3_harmonize/src/clean_wqp_data.R
+++ b/3_harmonize/src/clean_wqp_data.R
@@ -74,6 +74,7 @@ clean_wqp_data <- function(wqp_data, char_names_crosswalk,
 #' Function to flag true missing results, i.e. when the result measure value 
 #' and detection limit value are both NA, when "not reported" is found in the
 #' column "ResultDetectionConditionText", or when any of the strings from
+#' `commenttext_missing` are found in the column "ResultCommentText".
 #' 
 #' @param wqp_data data frame containing the data downloaded from the WQP, 
 #' where each row represents a data record. Must contain the columns

--- a/3_harmonize/src/clean_wqp_data.R
+++ b/3_harmonize/src/clean_wqp_data.R
@@ -52,7 +52,8 @@ clean_wqp_data <- function(wqp_data, char_names_crosswalk,
     mutate(flag_missing_result = case_when(
       is.na(ResultMeasureValue) & is.na(DetectionQuantitationLimitMeasure.MeasureValue) ~ TRUE,
       grepl("not reported", ResultDetectionConditionText, ignore.case = TRUE) ~ TRUE,
-      grepl(paste(commenttext_missing, collapse = "|"), ResultCommentText, ignore.case = TRUE) ~ TRUE
+      grepl(paste(commenttext_missing, collapse = "|"), ResultCommentText, ignore.case = TRUE) ~ TRUE,
+      TRUE ~ FALSE
     )) %>%
     # Flag duplicate records
     flag_duplicates(., duplicate_definition)
@@ -89,13 +90,13 @@ flag_duplicates <- function(wqp_data, duplicate_definition){
     # Step 1: Flag duplicate records using the `duplicate_definition`
     group_by(across(all_of(duplicate_definition))) %>% 
     mutate(n_duplicated = n(),
-           flag_duplicated_row = if_else(n_duplicated > 1, TRUE, NA)) %>% 
+           flag_duplicated_row = if_else(n_duplicated > 1, TRUE, FALSE)) %>% 
     # Step 2: For remaining duplicates, randomly select the first record from
     # each duplicated set and flag all others for exclusion
     mutate(dup_number = seq(n_duplicated),
            flag_duplicate_drop_random = if_else(n_duplicated > 1 & 
                                                   dup_number != 1, 
-                                                TRUE, NA)) %>%
+                                                TRUE, FALSE)) %>%
     ungroup() %>%
     select(-c(n_duplicated, dup_number))
   

--- a/3_harmonize/src/clean_wqp_data.R
+++ b/3_harmonize/src/clean_wqp_data.R
@@ -54,14 +54,43 @@ clean_wqp_data <- function(wqp_data, char_names_crosswalk,
       grepl(paste(commenttext_missing, collapse = "|"), ResultCommentText, ignore.case = TRUE) ~ TRUE
     )) %>%
     # Flag duplicate records
-    group_by(across(all_of(duplicate_definition))) %>% 
-    mutate(n_duplicated = n(),
-           flag_duplicated_row = if_else(n_duplicated > 1, TRUE, NA)) %>% 
-    ungroup()%>%
-    select(-n_duplicated)
+    flag_duplicates(., duplicate_definition)
   
   return(wqp_data_clean)
   
   
 }
+
+
+#' @title Flag duplicated records
+#' 
+#' @description 
+#' Function to flag duplicated rows based on a user-supplied definition
+#' of a duplicate record. 
+#' 
+#' @param wqp_data data frame containing the data downloaded from the WQP, 
+#' where each row represents a unique data record.
+#' @param duplicate_definition character string(s) indicating which columns are
+#' used to identify a duplicate record. Duplicate records are defined as those 
+#' that share the same value for each column within `duplicate_definition`.
+#'
+#' @returns 
+#' Returns a data frame containing data downloaded from the Water Quality Portal,
+#' where each row represents a unique data record. New columns appended to the 
+#' original data frame include flags for duplicated records. 
+#' 
+flag_duplicates <- function(wqp_data, duplicate_definition){
+  
+  wqp_data_out <- wqp_data %>%
+    # Flag duplicate records using the `duplicate_definition`
+    group_by(across(all_of(duplicate_definition))) %>% 
+    mutate(n_duplicated = n(),
+           flag_duplicated_row = if_else(n_duplicated > 1, TRUE, NA)) %>% 
+    ungroup() %>%
+    select(-n_duplicated)
+  
+  return(wqp_data_out)
+  
+}
+
 


### PR DESCRIPTION
This PR adds code to the `clean_wqp_data()` function to flag true missing results as well as duplicated records. Both of these steps are inspired by data cleaning steps in the proxies example files in this repo. 

I want to keep data cleaning steps fairly "light touch" in this example repo, but I know the step to identify and resolve duplicates can get much more complex in many WQP workflows (e.g. [this](https://www.sciencebase.gov/catalog/item/5e010424e4b0b207aa033d8c) effort to harmonize WQP data across many characteristics in the Delaware River Basin). To make the data cleaning code more modular and hopefully enable further development by individual users, I've split off the step to flag duplicates into a separate function, `flag_duplicates()`. I kind of struggled with a "right-sized" example for this repo. Just flagging the duplicates doesn't actually help the user to resolve those duplicate sets since we presumably would want to keep one record for each duplicate set. So I added another flag based on the assumption that we'd randomly drop all duplicates except for the first one. Our code doesn't currently do anything with this extra bit of information, and I'm on the fence as to whether to drop duplicates or just flag them in this workflow. I'd be interested to hear what other thoughts you have. 

Here's what I get when I run the code:

```r
> tar_load(p3_wqp_data_aoi_clean)
>
> p3_wqp_data_aoi_clean %>%
+     group_by(flag_missing_result) %>%
+     summarize(n = n())
# A tibble: 2 x 2
  flag_missing_result     n
  <lgl>               <int>
1 TRUE                    1
2 NA                  20265
>
> p3_wqp_data_aoi_clean %>%
+   group_by(flag_duplicated_row) %>%
+   summarize(n = n())
# A tibble: 2 x 2
  flag_duplicated_row     n
  <lgl>               <int>
1 TRUE                 7808
2 NA                  12458
>
```

Closes #16 