### PR TITLE
Harmonize temperature and conductivity units

### DIFF
--- a/3_harmonize.R
+++ b/3_harmonize.R
@@ -6,19 +6,26 @@ source("3_harmonize/src/clean_temperature_data.R")
 
 p3_targets_list <- list(
   
-  # All columns in p2_wqp_data_aoi are of class character. Coerce select columns
-  # back to numeric, but first retain original entries in new columns ending in 
-  # "_original". The default option is to format "ResultMeasureValue" and 
-  # "DetectionQuantitationLimitMeasure.MeasureValue" to numeric, but additional
-  # variables can be added using the `vars_to_numeric` argument in format_columns().
-  # By default, format_columns() will retain all columns, but undesired variables 
-  # can also be dropped from the WQP dataset using the optional `drop_vars` argument. 
+  # All columns in p2_wqp_data_aoi are of class character. Coerce select 
+  # columns back to numeric, but first retain original entries in new columns
+  # ending in "_original". The default option is to format "ResultMeasureValue"
+  # and "DetectionQuantitationLimitMeasure.MeasureValue" to numeric, but 
+  # additional variables can be added using the `vars_to_numeric` argument in 
+  # format_columns(). By default, format_columns() will retain all columns, but
+  # undesired variables can also be dropped from the WQP dataset using the 
+  # optional `drop_vars` argument. 
   tar_target(
     p3_wqp_data_aoi_formatted,
     format_columns(p2_wqp_data_aoi)
   ),
   
-  # Harmonize WQP data
+  # Harmonize WQP data. Duplicated rows are identified using the argument
+  # `duplicate_definition`. By default, a record will be considered duplicated
+  # if it shares the same organization, site id, date, time, characteristic name,
+  # and sample fraction, although a different vector of column names can be 
+  # passed to `clean_wqp_data()` below. By default, duplicated rows are flagged
+  # and omitted from the dataset. To retain duplicate rows, set the argument 
+  # `remove_duplicated_rows` to FALSE. 
   tar_target(
     p3_wqp_data_aoi_clean,
     clean_wqp_data(p3_wqp_data_aoi_formatted, p1_char_names_crosswalk)

--- a/3_harmonize.R
+++ b/3_harmonize.R
@@ -34,7 +34,7 @@ p3_targets_list <- list(
   ),
   
   # Group the WQP data by parameter group in preparation for parameter-specific
-  # data cleaning steps
+  # data cleaning steps.
   tar_target(
     p3_wqp_data_aoi_clean_grp,
     p3_wqp_data_aoi_clean %>%
@@ -44,23 +44,27 @@ p3_targets_list <- list(
   ),
 
   # Create a table that defines parameter-specific data cleaning functions.
+  # Cleaning functions should be defined within a named list where the name
+  # of the function defines each list element. 
   tar_target(
     p3_wqp_param_cleaning_info,
     tibble(
       parameter_grp_name = c('conductivity', 'temperature'),
-      cleaning_fxn = c('clean_conductivity_data', 'clean_temperature_data')
+      cleaning_fxn = list(clean_conductivity_data = clean_conductivity_data, 
+                          clean_temperature_data = clean_temperature_data)
     )
   ),
   
   # Harmonize WQP data by applying parameter-specific data cleaning steps to
-  # including harmonizing units where possible. 
+  # including harmonizing units where possible.
   tar_target(
     p3_wqp_data_aoi_clean_param,
     {
       # Decide which function to use
       fxn_to_use <- p3_wqp_param_cleaning_info %>%
         filter(parameter_grp_name == unique(p3_wqp_data_aoi_clean_grp$parameter)) %>%
-        pull(cleaning_fxn)
+        pull(cleaning_fxn) %>%
+        names()
       
       # If applicable, apply parameter-specific cleaning function
       if(length(fxn_to_use) > 0){

--- a/3_harmonize.R
+++ b/3_harmonize.R
@@ -19,13 +19,15 @@ p3_targets_list <- list(
     format_columns(p2_wqp_data_aoi)
   ),
   
-  # Harmonize WQP data. Duplicated rows are identified using the argument
-  # `duplicate_definition`. By default, a record will be considered duplicated
-  # if it shares the same organization, site id, date, time, characteristic name,
-  # and sample fraction, although a different vector of column names can be 
-  # passed to `clean_wqp_data()` below. By default, duplicated rows are flagged
-  # and omitted from the dataset. To retain duplicate rows, set the argument 
-  # `remove_duplicated_rows` to FALSE. 
+  # Harmonize WQP data by uniting diverse characteristic names under more
+  # commonly-used water quality parameter names; flagging missing records and
+  # duplicate records; and harmonizing diverse units where possible. Duplicated
+  # rows are identified using the argument `duplicate_definition`. By default, 
+  # a record will be considered duplicated if it shares the same organization, 
+  # site id, date, time, characteristic name, and sample fraction, although a 
+  # different vector of column names can be passed to `clean_wqp_data()` below.
+  # By default, duplicated rows are flagged and omitted from the dataset. To 
+  # retain duplicate rows, set the argument `remove_duplicated_rows` to FALSE. 
   tar_target(
     p3_wqp_data_aoi_clean,
     clean_wqp_data(p3_wqp_data_aoi_formatted, p1_char_names_crosswalk)

--- a/3_harmonize.R
+++ b/3_harmonize.R
@@ -35,7 +35,7 @@ p3_targets_list <- list(
   
   # Create a table that defines parameter-specific data cleaning functions.
   # Cleaning functions should be defined within a named list where the name
-  # of the function defines each list element. 
+  # of each list element is the function name.
   tar_target(
     p3_wqp_param_cleaning_info,
     tibble(
@@ -56,8 +56,11 @@ p3_targets_list <- list(
     iteration = "group"
   ),
   
-  # Harmonize WQP data by applying parameter-specific data cleaning steps to
-  # including harmonizing units where possible.
+  # Harmonize WQP data by applying parameter-specific data cleaning steps,
+  # including harmonizing units where possible. `p3_wqp_param_cleaning_info` 
+  # is a {targets} dependency, so changes to any of the parameter-specific 
+  # cleaning functions will trigger a rebuild of only those branches that 
+  # correspond to the group of data impacted by the change.
   tar_target(
     p3_wqp_data_aoi_clean_param,
     {

--- a/3_harmonize.R
+++ b/3_harmonize.R
@@ -2,6 +2,7 @@
 source("3_harmonize/src/format_columns.R")
 source("3_harmonize/src/clean_wqp_data.R")
 source("3_harmonize/src/clean_conductivity_data.R")
+source("3_harmonize/src/clean_temperature_data.R")
 
 p3_targets_list <- list(
   

--- a/3_harmonize.R
+++ b/3_harmonize.R
@@ -1,6 +1,7 @@
 # Source the functions that will be used to build the targets in p3_targets_list
 source("3_harmonize/src/format_columns.R")
 source("3_harmonize/src/clean_wqp_data.R")
+source("3_harmonize/src/clean_conductivity_data.R")
 
 p3_targets_list <- list(
   

--- a/3_harmonize/src/clean_conductivity_data.R
+++ b/3_harmonize/src/clean_conductivity_data.R
@@ -5,12 +5,6 @@
 #' 
 #' @param wqp_data data frame containing the data downloaded from the WQP, 
 #' where each row represents a data record.
-#' @param char_names_crosswalk data frame containing columns "char_name" and 
-#' "parameter". The column "char_name" contains character strings representing 
-#' known WQP characteristic names associated with each parameter.
-#' @param cond_param_name character string indicating which string in the 
-#' "parameter" column of `char_names_crosswalk` corresponds with conductivity 
-#' data.
 #' 
 #' @returns 
 #' Returns a formatted and harmonized data frame containing data downloaded from 

--- a/3_harmonize/src/clean_conductivity_data.R
+++ b/3_harmonize/src/clean_conductivity_data.R
@@ -8,18 +8,20 @@
 #' @param char_names_crosswalk data frame containing columns "char_name" and 
 #' "parameter". The column "char_name" contains character strings representing 
 #' known WQP characteristic names associated with each parameter.
+#' @param cond_param_name character string indicating which string in the 
+#' "parameter" column of `char_names_crosswalk` corresponds with conductivity 
+#' data.
 #' 
 #' @returns 
 #' Returns a formatted and harmonized data frame containing data downloaded from 
 #' the Water Quality Portal, where each row represents a data record. Conductivity
 #' units have been standardized to uS/cm where possible. 
 #' 
-clean_conductivity_data <- function(wqp_data, char_names_crosswalk){
+clean_conductivity_data <- function(wqp_data, char_names_crosswalk, cond_param_name){
   
-  # Grab the characteristic names associated with parameter 'conductivity'
-  # from `char_names_crosswalk`
+  # Grab characteristic names associated with conductivity in `char_names_crosswalk`
   cond_char_names <- char_names_crosswalk %>%
-    filter(parameter == "conductivity") %>%
+    filter(parameter == cond_param_name) %>%
     pull(char_name)
   
   # Harmonize conductivity units when possible

--- a/3_harmonize/src/clean_conductivity_data.R
+++ b/3_harmonize/src/clean_conductivity_data.R
@@ -1,0 +1,69 @@
+#' @title Clean conductivity data
+#' 
+#' @description 
+#' Function to clean conductivity data, including harmonizing diverse units. 
+#' 
+#' @param wqp_data data frame containing the data downloaded from the WQP, 
+#' where each row represents a data record.
+#' @param char_names_crosswalk data frame containing columns "char_name" and 
+#' "parameter". The column "char_name" contains character strings representing 
+#' known WQP characteristic names associated with each parameter.
+#' 
+#' @returns 
+#' Returns a formatted and harmonized data frame containing data downloaded from 
+#' the Water Quality Portal, where each row represents a data record. Conductivity
+#' units have been standardized to uS/cm where possible. 
+#' 
+clean_conductivity_data <- function(wqp_data, char_names_crosswalk){
+  
+  # Grab the characteristic names associated with parameter 'conductivity'
+  # from `char_names_crosswalk`
+  cond_char_names <- char_names_crosswalk %>%
+    filter(parameter == "conductivity") %>%
+    pull(char_name)
+  
+  # Harmonize conductivity units when possible
+  wqp_data_out <- wqp_data %>%
+    # convert values from mS/cm to uS/cm
+    mutate(ResultMeasureValue = if_else(CharacteristicName %in% cond_char_names & 
+                                          !is.na(ResultMeasureValue) & 
+                                          ResultMeasure.MeasureUnitCode == "mS/cm",
+                                        (ResultMeasureValue * 1000), ResultMeasureValue),
+           # update units in column "ResultMeasure.MeasureUnitCode"
+           ResultMeasure.MeasureUnitCode = case_when(
+             # convert mS/cm to uS/cm
+             CharacteristicName %in% cond_char_names & 
+               !is.na(ResultMeasureValue) & 
+               ResultMeasure.MeasureUnitCode == "mS/cm" ~ "uS/cm",
+             # convert equivalent units (umho/cm) to uS/cm
+             CharacteristicName %in% cond_char_names & 
+               !is.na(ResultMeasureValue) & 
+               ResultMeasure.MeasureUnitCode == "umho/cm" ~ "uS/cm",
+             # if result measure unit code is NA but units are reported for
+             # the detection quantitation limit, assume that the quantitation
+             # units also apply to the result value
+             CharacteristicName %in% cond_char_names & 
+               is.na(ResultMeasure.MeasureUnitCode) &
+               !is.na(DetectionQuantitationLimitMeasure.MeasureUnitCode) ~
+               DetectionQuantitationLimitMeasure.MeasureUnitCode,
+             # attempt to standardize units using temperature basis
+             CharacteristicName %in% cond_char_names &
+               !is.na(ResultMeasureValue) & 
+               ResultMeasure.MeasureUnitCode == "uS/cm" &
+               grepl("25 deg C", ResultTemperatureBasisText, ignore.case = TRUE) ~
+               paste0(ResultMeasure.MeasureUnitCode, " @25C"),
+             TRUE ~ ResultMeasure.MeasureUnitCode)
+           ) %>%
+    # assume that uS/cm is equivalent to uS/cm at 25 degrees C
+    mutate(ResultMeasure.MeasureUnitCode = if_else(CharacteristicName %in% cond_char_names & 
+                                                     !is.na(ResultMeasureValue) & 
+                                                     ResultMeasure.MeasureUnitCode == "uS/cm @25C", 
+                                                   "uS/cm", ResultMeasure.MeasureUnitCode))
+          
+  return(wqp_data_out)
+}
+
+
+
+
+                                    

--- a/3_harmonize/src/clean_temperature_data.R
+++ b/3_harmonize/src/clean_temperature_data.R
@@ -5,12 +5,6 @@
 #' 
 #' @param wqp_data data frame containing the data downloaded from the WQP, 
 #' where each row represents a data record.
-#' @param char_names_crosswalk data frame containing columns "char_name" and 
-#' "parameter". The column "char_name" contains character strings representing 
-#' known WQP characteristic names associated with each parameter.
-#' @param temp_param_name character string indicating which string in the 
-#' "parameter" column of `char_names_crosswalk` corresponds with temperature
-#' data. 
 #' 
 #' @returns 
 #' Returns a formatted and harmonized data frame containing data downloaded from 

--- a/3_harmonize/src/clean_temperature_data.R
+++ b/3_harmonize/src/clean_temperature_data.R
@@ -26,15 +26,17 @@ clean_temperature_data <- function(wqp_data, char_names_crosswalk, temp_param_na
   
   # Clean temperature data
   wqp_data_out <- wqp_data %>%
+    # create logical variable to use for filtering rows to apply cleaning steps
+    mutate(is_nonNA_temperature = CharacteristicName %in% temp_char_names &
+             !is.na(ResultMeasureValue)) %>%
     # harmonize units
-    mutate(ResultMeasureValue = if_else(CharacteristicName %in% temp_char_names & 
-                                          !is.na(ResultMeasureValue) & 
+    mutate(ResultMeasureValue = if_else(is_nonNA_temperature & 
                                           ResultMeasure.MeasureUnitCode == "deg F",
                                         ((ResultMeasureValue - 32) * (5/9)), ResultMeasureValue),
-           ResultMeasure.MeasureUnitCode = if_else(CharacteristicName %in% temp_char_names &
-                                                     !is.na(ResultMeasureValue) & 
+           ResultMeasure.MeasureUnitCode = if_else(is_nonNA_temperature & 
                                                      ResultMeasure.MeasureUnitCode == "deg F",
-                                                   "deg C", ResultMeasure.MeasureUnitCode))
+                                                   "deg C", ResultMeasure.MeasureUnitCode)) %>%
+    select(-is_nonNA_temperature)
   
   return(wqp_data_out)
   

--- a/3_harmonize/src/clean_temperature_data.R
+++ b/3_harmonize/src/clean_temperature_data.R
@@ -17,26 +17,17 @@
 #' the Water Quality Portal, where each row represents a data record. Temperature
 #' units have been standardized to degrees celsius where possible. 
 #' 
-clean_temperature_data <- function(wqp_data, char_names_crosswalk, temp_param_name){
-  
-  # Grab characteristic names associated with temperature in `char_names_crosswalk`
-  temp_char_names <- char_names_crosswalk %>%
-    filter(parameter == temp_param_name) %>%
-    pull(char_name)
-  
+clean_temperature_data <- function(wqp_data){
+
   # Clean temperature data
   wqp_data_out <- wqp_data %>%
-    # create logical variable to use for filtering rows to apply cleaning steps
-    mutate(is_nonNA_temperature = CharacteristicName %in% temp_char_names &
-             !is.na(ResultMeasureValue)) %>%
     # harmonize units
-    mutate(ResultMeasureValue = if_else(is_nonNA_temperature & 
+    mutate(ResultMeasureValue = if_else(!is.na(ResultMeasureValue) & 
                                           ResultMeasure.MeasureUnitCode == "deg F",
                                         ((ResultMeasureValue - 32) * (5/9)), ResultMeasureValue),
-           ResultMeasure.MeasureUnitCode = if_else(is_nonNA_temperature & 
+           ResultMeasure.MeasureUnitCode = if_else(!is.na(ResultMeasureValue) & 
                                                      ResultMeasure.MeasureUnitCode == "deg F",
-                                                   "deg C", ResultMeasure.MeasureUnitCode)) %>%
-    select(-is_nonNA_temperature)
+                                                   "deg C", ResultMeasure.MeasureUnitCode)) 
   
   return(wqp_data_out)
   

--- a/3_harmonize/src/clean_temperature_data.R
+++ b/3_harmonize/src/clean_temperature_data.R
@@ -1,0 +1,44 @@
+#' @title Clean temperature data
+#' 
+#' @description 
+#' Function to clean temperature data, including harmonizing diverse units. 
+#' 
+#' @param wqp_data data frame containing the data downloaded from the WQP, 
+#' where each row represents a data record.
+#' @param char_names_crosswalk data frame containing columns "char_name" and 
+#' "parameter". The column "char_name" contains character strings representing 
+#' known WQP characteristic names associated with each parameter.
+#' @param temp_param_name character string indicating which string in the 
+#' "parameter" column of `char_names_crosswalk` corresponds with temperature
+#' data. 
+#' 
+#' @returns 
+#' Returns a formatted and harmonized data frame containing data downloaded from 
+#' the Water Quality Portal, where each row represents a data record. Temperature
+#' units have been standardized to degrees celsius where possible. 
+#' 
+clean_temperature_data <- function(wqp_data, char_names_crosswalk, temp_param_name){
+  
+  # Grab characteristic names associated with temperature in `char_names_crosswalk`
+  temp_char_names <- char_names_crosswalk %>%
+    filter(parameter == temp_param_name) %>%
+    pull(char_name)
+  
+  # Clean temperature data
+  wqp_data_out <- wqp_data %>%
+    # harmonize units
+    mutate(ResultMeasureValue = if_else(CharacteristicName %in% temp_char_names & 
+                                          !is.na(ResultMeasureValue) & 
+                                          ResultMeasure.MeasureUnitCode == "deg F",
+                                        ((ResultMeasureValue - 32) * (5/9)), ResultMeasureValue),
+           ResultMeasure.MeasureUnitCode = if_else(CharacteristicName %in% temp_char_names &
+                                                     !is.na(ResultMeasureValue) & 
+                                                     ResultMeasure.MeasureUnitCode == "deg F",
+                                                   "deg C", ResultMeasure.MeasureUnitCode))
+  
+  return(wqp_data_out)
+  
+}
+
+
+                                    

--- a/3_harmonize/src/clean_temperature_data.R
+++ b/3_harmonize/src/clean_temperature_data.R
@@ -17,10 +17,10 @@ clean_temperature_data <- function(wqp_data){
   wqp_data_out <- wqp_data %>%
     # harmonize units
     mutate(ResultMeasureValue = if_else(!is.na(ResultMeasureValue) & 
-                                          ResultMeasure.MeasureUnitCode == "deg F",
+                                          grepl("deg F", ResultMeasure.MeasureUnitCode, ignore.case = TRUE),
                                         ((ResultMeasureValue - 32) * (5/9)), ResultMeasureValue),
            ResultMeasure.MeasureUnitCode = if_else(!is.na(ResultMeasureValue) & 
-                                                     ResultMeasure.MeasureUnitCode == "deg F",
+                                                     grepl("deg F", ResultMeasure.MeasureUnitCode, ignore.case = TRUE),
                                                    "deg C", ResultMeasure.MeasureUnitCode)) 
   
   return(wqp_data_out)

--- a/3_harmonize/src/clean_wqp_data.R
+++ b/3_harmonize/src/clean_wqp_data.R
@@ -3,8 +3,10 @@
 #' @description 
 #' Function to harmonize WQP data in preparation for further analysis. Included
 #' in this function are steps to unite diverse characteristic names by assigning
-#' them to more commonly-used water quality parameter names, and to flag missing
-#' records as well as duplicate records.
+#' them to more commonly-used water quality parameter names; to flag missing
+#' records as well as duplicate records; and to carry out parameter-specific
+#' harmonization steps for temperature and conductivity data, including
+#' harmonizing units where possible. 
 #' 
 #' @param wqp_data data frame containing the data downloaded from the WQP, 
 #' where each row represents a data record. 

--- a/3_harmonize/src/clean_wqp_data.R
+++ b/3_harmonize/src/clean_wqp_data.R
@@ -50,6 +50,8 @@ clean_wqp_data <- function(wqp_data, char_names_crosswalk,
     left_join(y = char_names_crosswalk, by = c("CharacteristicName" = "char_name")) %>%
     # flag true missing results
     flag_missing_results(., commenttext_missing) %>%
+    # harmonize conductivity units
+    clean_conductivity_data(., char_names_crosswalk) %>%
     # flag duplicate records
     flag_duplicates(., duplicate_definition) %>%
     {if(remove_duplicated_rows){

--- a/3_harmonize/src/clean_wqp_data.R
+++ b/3_harmonize/src/clean_wqp_data.R
@@ -19,12 +19,6 @@
 #' strings: "analysis lost", "not analyzed", "not recorded", "not collected", 
 #' and "no measurement taken", but other values may be added by passing in a new
 #' vector with all values to be treated as missing.  
-#' @param cond_param_name character string indicating which string in the 
-#' "parameter" column of `char_names_crosswalk` corresponds with conductivity 
-#' data. Default value is 'conductivity'.
-#' @param temp_param_name character string indicating which string in the 
-#' "parameter" column of `char_names_crosswalk` corresponds with temperature
-#' data. Default value is 'temperature'.
 #' @param duplicate_definition character string(s) indicating which columns are
 #' used to identify a duplicate record. Duplicate records are defined as those 
 #' that share the same value for each column within `duplicate_definition`. By 
@@ -43,8 +37,6 @@ clean_wqp_data <- function(wqp_data, char_names_crosswalk,
                            commenttext_missing = c('analysis lost', 'not analyzed', 
                                                    'not recorded', 'not collected', 
                                                    'no measurement taken'),
-                           cond_param_name = 'conductivity',
-                           temp_param_name = 'temperature',
                            duplicate_definition = c('OrganizationIdentifier',
                                                     'MonitoringLocationIdentifier',
                                                     'ActivityStartDate', 
@@ -60,10 +52,6 @@ clean_wqp_data <- function(wqp_data, char_names_crosswalk,
     left_join(y = char_names_crosswalk, by = c("CharacteristicName" = "char_name")) %>%
     # flag true missing results
     flag_missing_results(., commenttext_missing) %>%
-    # harmonize conductivity units
-    clean_conductivity_data(., char_names_crosswalk, cond_param_name) %>%
-    # harmonize temperature units
-    clean_temperature_data(., char_names_crosswalk, temp_param_name) %>% 
     # flag duplicate records
     flag_duplicates(., duplicate_definition) %>%
     {if(remove_duplicated_rows){

--- a/3_harmonize/src/clean_wqp_data.R
+++ b/3_harmonize/src/clean_wqp_data.R
@@ -20,6 +20,9 @@
 #' @param cond_param_name character string indicating which string in the 
 #' "parameter" column of `char_names_crosswalk` corresponds with conductivity 
 #' data. Default value is 'conductivity'.
+#' @param temp_param_name character string indicating which string in the 
+#' "parameter" column of `char_names_crosswalk` corresponds with temperature
+#' data. Default value is 'temperature'.
 #' @param duplicate_definition character string(s) indicating which columns are
 #' used to identify a duplicate record. Duplicate records are defined as those 
 #' that share the same value for each column within `duplicate_definition`. By 
@@ -39,6 +42,7 @@ clean_wqp_data <- function(wqp_data, char_names_crosswalk,
                                                    'not recorded', 'not collected', 
                                                    'no measurement taken'),
                            cond_param_name = 'conductivity',
+                           temp_param_name = 'temperature',
                            duplicate_definition = c('OrganizationIdentifier',
                                                     'MonitoringLocationIdentifier',
                                                     'ActivityStartDate', 
@@ -56,6 +60,8 @@ clean_wqp_data <- function(wqp_data, char_names_crosswalk,
     flag_missing_results(., commenttext_missing) %>%
     # harmonize conductivity units
     clean_conductivity_data(., char_names_crosswalk, cond_param_name) %>%
+    # harmonize temperature units
+    clean_temperature_data(., char_names_crosswalk, temp_param_name) %>% 
     # flag duplicate records
     flag_duplicates(., duplicate_definition) %>%
     {if(remove_duplicated_rows){

--- a/3_harmonize/src/clean_wqp_data.R
+++ b/3_harmonize/src/clean_wqp_data.R
@@ -17,6 +17,9 @@
 #' strings: "analysis lost", "not analyzed", "not recorded", "not collected", 
 #' and "no measurement taken", but other values may be added by passing in a new
 #' vector with all values to be treated as missing.  
+#' @param cond_param_name character string indicating which string in the 
+#' "parameter" column of `char_names_crosswalk` corresponds with conductivity 
+#' data. Default value is 'conductivity'.
 #' @param duplicate_definition character string(s) indicating which columns are
 #' used to identify a duplicate record. Duplicate records are defined as those 
 #' that share the same value for each column within `duplicate_definition`. By 
@@ -35,6 +38,7 @@ clean_wqp_data <- function(wqp_data, char_names_crosswalk,
                            commenttext_missing = c('analysis lost', 'not analyzed', 
                                                    'not recorded', 'not collected', 
                                                    'no measurement taken'),
+                           cond_param_name = 'conductivity',
                            duplicate_definition = c('OrganizationIdentifier',
                                                     'MonitoringLocationIdentifier',
                                                     'ActivityStartDate', 
@@ -51,7 +55,7 @@ clean_wqp_data <- function(wqp_data, char_names_crosswalk,
     # flag true missing results
     flag_missing_results(., commenttext_missing) %>%
     # harmonize conductivity units
-    clean_conductivity_data(., char_names_crosswalk) %>%
+    clean_conductivity_data(., char_names_crosswalk, cond_param_name) %>%
     # flag duplicate records
     flag_duplicates(., duplicate_definition) %>%
     {if(remove_duplicated_rows){

--- a/3_harmonize/src/clean_wqp_data.R
+++ b/3_harmonize/src/clean_wqp_data.R
@@ -127,7 +127,8 @@ flag_duplicates <- function(wqp_data, duplicate_definition){
     group_by(across(all_of(duplicate_definition))) %>% 
     mutate(n_duplicated = n(),
            flag_duplicated_row = n_duplicated > 1) %>% 
-    ungroup()
+    ungroup() %>%
+    select(-n_duplicated)
   
   return(wqp_data_out)
   
@@ -157,7 +158,8 @@ remove_duplicates <- function(wqp_data, duplicate_definition){
     group_by(across(all_of(duplicate_definition))) %>% 
     # To help resolve duplicates, randomly select the first record
     # from each duplicated set and flag all others for exclusion.
-    mutate(dup_number = seq(n_duplicated),
+    mutate(n_duplicated = n(),
+           dup_number = seq(n_duplicated),
            flag_duplicate_drop_random = n_duplicated > 1 & dup_number != 1) %>%
     filter(flag_duplicate_drop_random == FALSE) %>%
     ungroup() %>%


### PR DESCRIPTION
This PR adds two parameter-specific harmonization functions to the pipeline, including `clean_temperature_data()` and `clean_conductivity_data()`. Both functions are called within `clean_wqp_data()` and are used to harmonize reported units when possible. A user could add additional cleaning steps specific to temperature or conductivity data to these functions. 

Here is what I see after running the pipeline:

```r
> tar_load(p3_wqp_data_aoi_clean)
> p3_wqp_data_aoi_clean %>%
+     group_by(CharacteristicName, ResultMeasure.MeasureUnitCode) %>%
+     summarize(n = n())
`summarise()` has grouped output by 'CharacteristicName'. You can override using the `.groups` argument.
# A tibble: 5 x 3
# Groups:   CharacteristicName [4]
  CharacteristicName                              ResultMeasure.MeasureUnitCode     n
  <chr>                                           <chr>                         <int>
1 Conductivity                                    uS/cm                             6
2 Specific conductance                            umho/cm                           6
3 Specific conductance                            uS/cm                          7550
4 Specific Conductance, Calculated/Measured Ratio uS/cm                            42
5 Temperature, water                              deg C                          8333
> 
```

The new functions attempt to harmonize units to degrees C and uS/cm for temperature and conductivity data, respectively. You can see here that 6 records still have the less-desirable "umho/cm" units because those rows do not actually contain any data in `ResultMeasureValue`:

```r
> p3_wqp_data_aoi_clean %>%
+   filter(ResultMeasure.MeasureUnitCode == "umho/cm") %>%
+   select(ResultMeasureValue, DetectionQuantitationLimitMeasure.MeasureValue)
# A tibble: 6 x 2
  ResultMeasureValue DetectionQuantitationLimitMeasure.MeasureValue
               <dbl>                                          <dbl>
1                 NA                                              1
2                 NA                                              1
3                 NA                                              1
4                 NA                                              1
5                 NA                                              1
6                 NA                                              1
>
```

I have not included a function to harmonize the data using detection limit information, as is done in the PROXIES example code and in DRB IWAAs scripts I've worked with before. We could add a function to do that, but so far I've considered that outside the scope of this example pipeline. 


Closes #27 