### PR TITLE
Simplify `identify_bad_ids()`

### DIFF
--- a/2_download/src/fetch_wqp_data.R
+++ b/2_download/src/fetch_wqp_data.R
@@ -22,11 +22,11 @@
 #' 
 identify_bad_ids <- function(sitecounts_df){
   
-  # Check that string format matches regex used in WQP and doesn't contain "/"
+  # Check that string format matches regex used in WQP
   sitecounts_bad_ids <- sitecounts_df %>%
     rename(site_id = MonitoringLocationIdentifier) %>% 
     mutate(site_id_regex = stringr::str_extract(site_id, "[\\w]+\\-.*\\S")) %>%
-    filter(site_id != site_id_regex | grepl("/", site_id)) %>%
+    filter(site_id != site_id_regex) %>%
     select(-site_id_regex)
 
   return(sitecounts_bad_ids)


### PR DESCRIPTION
This PR simplifies the function `identify_bad_ids()` by omitting a redundant step that searched for the character `"/"` in `MonitoringLocationIdentifier` in addition to the regex check.

The output of this function should not change as a result of this edit. For example:

```r
> library(tidyverse)
> 
> # Current function, which includes a regex check and a separate check for "/"
> identify_bad_ids_old <- function(sitecounts_df){
+   
+   # Check that string format matches regex used in WQP and doesn't contain "/"
+   sitecounts_bad_ids <- sitecounts_df %>%
+     rename(site_id = MonitoringLocationIdentifier) %>% 
+     mutate(site_id_regex = stringr::str_extract(site_id, "[\\w]+\\-.*\\S")) %>%
+     filter(site_id != site_id_regex | grepl("/", site_id)) %>%
+     select(-site_id_regex)
+   
+   return(sitecounts_bad_ids)
+ }
> 
> # Proposed function, which includes a regex check that should capture sites with "/"
> identify_bad_ids <- function(sitecounts_df){
+   
+   # Check that string format matches regex used in WQP 
+   sitecounts_bad_ids <- sitecounts_df %>%
+     rename(site_id = MonitoringLocationIdentifier) %>% 
+     mutate(site_id_regex = stringr::str_extract(site_id, "[\\w]+\\-.*\\S")) %>%
+     filter(site_id != site_id_regex) %>%
+     select(-site_id_regex)
+   
+   return(sitecounts_bad_ids)
+ }
> 
> bad_sites_test <- tibble(MonitoringLocationIdentifier = c("USGS-01234",
+                                                           "COE/ISU-27630001",
+                                                           "ALABAMACOUSHATTATRIBE.TX_WQX-TL-007",
+                                                           "NALMS-C41.59831,-93.60861"),
+                          results_count = c(500,3,10,2))
> identify_bad_ids_old(bad_sites_test)
# A tibble: 2 x 2
  site_id                             results_count
  <chr>                                       <dbl>
1 COE/ISU-27630001                                3
2 ALABAMACOUSHATTATRIBE.TX_WQX-TL-007            10
>
> identify_bad_ids(bad_sites_test)
# A tibble: 2 x 2
  site_id                             results_count
  <chr>                                       <dbl>
1 COE/ISU-27630001                                3
2 ALABAMACOUSHATTATRIBE.TX_WQX-TL-007            10
> 
```

@jordansread, do you mind checking this function against your "big database of bad sites"? 😃 

Closes #76 