### PR TITLE
Check dataRetrieval package version 

### DIFF
--- a/1_inventory/src/get_wqp_inventory.R
+++ b/1_inventory/src/get_wqp_inventory.R
@@ -30,6 +30,13 @@ library(sf)
 
 inventory_wqp <- function(grid, char_names, wqp_args = NULL, max_tries = 3){
   
+  # First, check dataRetrieval package version and inform user if outdated
+  if((packageVersion('dataRetrieval') < "2.7.6.9003")){
+    stop(sprintf(paste0("dataRetrieval version %s is installed but this pipeline ",
+                        "requires package 2.7.6.9003. Please update dataRetrieval."),
+                 packageVersion('dataRetrieval')))
+  }
+  
   # Get bounding box for the grid polygon
   bbox <- sf::st_bbox(grid)
   

--- a/1_inventory/src/get_wqp_inventory.R
+++ b/1_inventory/src/get_wqp_inventory.R
@@ -31,7 +31,7 @@ library(sf)
 inventory_wqp <- function(grid, char_names, wqp_args = NULL, max_tries = 3){
   
   # First, check dataRetrieval package version and inform user if outdated
-  if((packageVersion('dataRetrieval') < "2.7.6.9003")){
+  if(packageVersion('dataRetrieval') < "2.7.6.9003"){
     stop(sprintf(paste0("dataRetrieval version %s is installed but this pipeline ",
                         "requires package 2.7.6.9003. Please update dataRetrieval."),
                  packageVersion('dataRetrieval')))


### PR DESCRIPTION
This PR adds a step in the `inventory_wqp()` function that checks the `dataRetrieval` package version and, if less than `2.7.6.9003`, stops the function and the pipeline. A message is printed asking the user to update their version of `dataRetrieval`. 

What do you think, @jordansread? Will this safeguard us against the errors you were getting from `whatWQPdata()` with older package versions?

Closes #82 