### PR TITLE
Simplify p3_wqp_param_cleaning_info

### DIFF
--- a/3_harmonize.R
+++ b/3_harmonize.R
@@ -66,7 +66,7 @@ p3_targets_list <- list(
       fxn_to_use <- p3_wqp_param_cleaning_info %>%
         filter(parameter == unique(p3_wqp_data_aoi_clean_grp$parameter)) %>%
         pull(cleaning_fxn) %>%
-        .[[1]]
+        {.[[1]]}
       
       # If applicable, apply parameter-specific cleaning function
       if(length(fxn_to_use) > 0){

--- a/3_harmonize.R
+++ b/3_harmonize.R
@@ -41,9 +41,7 @@ p3_targets_list <- list(
     p3_wqp_param_cleaning_info,
     tibble(
       parameter = c('conductivity', 'temperature'),
-      cleaning_fxn = list(clean_conductivity_data = clean_conductivity_data,
-                          clean_temperature_data = clean_temperature_data)
-    )
+      cleaning_fxn = c(clean_conductivity_data, clean_temperature_data))
   ),
   
   # Group the WQP data by parameter group in preparation for parameter-specific
@@ -51,7 +49,6 @@ p3_targets_list <- list(
   tar_target(
     p3_wqp_data_aoi_clean_grp,
     p3_wqp_data_aoi_clean %>%
-      left_join(p3_wqp_param_cleaning_info, by = "parameter") %>% 
       group_by(parameter) %>%
       tar_group(),
     iteration = "group"
@@ -66,10 +63,10 @@ p3_targets_list <- list(
     p3_wqp_data_aoi_clean_param,
     {
       # Decide which function to use
-      fxn_to_use <- p3_wqp_data_aoi_clean_grp %>%
+      fxn_to_use <- p3_wqp_param_cleaning_info %>%
+        filter(parameter == unique(p3_wqp_data_aoi_clean_grp$parameter)) %>%
         pull(cleaning_fxn) %>%
-        names() %>% 
-        unique()
+        .[[1]]
       
       # If applicable, apply parameter-specific cleaning function
       if(length(fxn_to_use) > 0){

--- a/README.md
+++ b/README.md
@@ -158,9 +158,7 @@ source("3_harmonize/src/clean_nitrate_data.R")
     p3_wqp_param_cleaning_info,
     tibble(
       parameter = c('conductivity', 'temperature', 'nitrate'),
-      cleaning_fxn = list(clean_conductivity_data = clean_conductivity_data,
-                          clean_temperature_data = clean_temperature_data,
-                          clean_nitrate_data = clean_nitrate_data)
+      cleaning_fxn = c(clean_conductivity_data, clean_temperature_data, clean_nitrate_data)
     )
   ),
 


### PR DESCRIPTION
This PR simplifies the target `p3_wqp_param_cleaning_info` by removing the need to name the function twice with `list(clean_conductivity_data = clean_conductivity_data))`. The code changes include:

- the parameter-specific cleaning functions are now defined as a vector containing the names of each function.
- modifications to `fxn_to_use` in `p3_wqp_data_aoi_clean_param` return the function associated with the parameter in a given branch of `p3_wqp_data_aoi_clean_grp`.

Closes #79