### PR TITLE
Convert missing value strings to NA

### DIFF
--- a/3_harmonize/src/format_columns.R
+++ b/3_harmonize/src/format_columns.R
@@ -3,8 +3,9 @@
 #' 
 #' @description
 #' Function to format WQP data columns, including to convert some columns of
-#' class character back to numeric. This function also presents the option 
-#' to drop undesired columns from the formatted data frame.
+#' class character back to numeric. This function also converts missing value
+#' strings to NA and presents the option to drop undesired columns from the 
+#' formatted data frame.
 #' 
 #' @param wqp_data data frame containing the data downloaded from the WQP, 
 #' where each row represents a unique data record.
@@ -59,7 +60,11 @@ format_columns <- function(wqp_data,
     # and so cannot be parsed to a numeric value.
     suppressWarnings() %>%
     # drop any undesired columns 
-    select(-c(any_of(drop_vars)))
+    select(-c(any_of(drop_vars))) %>%
+    # convert missing value strings ("", " ", "<Blank>") to NA
+    mutate(across(where(is.character), ~ na_if(.,""))) %>%
+    mutate(across(where(is.character), ~ na_if(.," "))) %>%
+    mutate(across(where(is.character), ~ na_if(.,"<Blank>")))
   
   return(wqp_data_out)
 }


### PR DESCRIPTION
This PR adds a step to `format_columns()` to convert missing value strings (e.g., "", " ", and "<Blank>") to `NA`. This code change should not impact the number of records in the harmonized data set or the contents of `p3_wqp_records_summary_csv`. 

Here is the output I see both before (top) and after (below) making these changes:

```r
> # Before making changes in this PR:
> tar_load(p3_wqp_data_aoi_formatted)
> which(p3_wqp_data_aoi_formatted == " ", arr.ind = TRUE) %>% head(3) # col 28 is "ActivityCommentText"
       row col
[1,] 12104  28
[2,] 12105  28
[3,] 12106  28
> which(p3_wqp_data_aoi_formatted == " ", arr.ind = TRUE) %>% dim()
[1] 634   2
> which(p3_wqp_data_aoi_formatted == "", arr.ind = TRUE) %>% dim()
[1] 0 2
> which(p3_wqp_data_aoi_formatted == "<Blank>", arr.ind = TRUE) %>% dim()
[1] 0 2
> 
```

```r
> # After running tar_make() with changes in this PR:
> tar_load(p3_wqp_data_aoi_formatted)
> which(p3_wqp_data_aoi_formatted == " ", arr.ind = TRUE) %>% head(3)
     row col
> which(p3_wqp_data_aoi_formatted == " ", arr.ind = TRUE) %>% dim()
[1] 0 2
> which(p3_wqp_data_aoi_formatted == "", arr.ind = TRUE) %>% dim()
[1] 0 2
> which(p3_wqp_data_aoi_formatted == "<Blank>", arr.ind = TRUE) %>% dim()
[1] 0 2
>
```