### PR TITLE
Make inventory step robust to empty queries 

### DIFF
--- a/1_inventory/src/get_wqp_inventory.R
+++ b/1_inventory/src/get_wqp_inventory.R
@@ -69,7 +69,7 @@ inventory_wqp <- function(grid, char_names, wqp_args = NULL, max_tries = 3){
       select(MonitoringLocationIdentifier, HorizontalCoordinateReferenceSystemDatumName) %>%
       filter(MonitoringLocationIdentifier %in% wqp_inventory$MonitoringLocationIdentifier),
     error = function(e){
-      data.frame(MonitoringLocationIdentifier = character())
+      data.frame(MonitoringLocationIdentifier = character(), HorizontalCoordinateReferenceSystemDatumName = character())
     }
   )
 

--- a/1_inventory/src/get_wqp_inventory.R
+++ b/1_inventory/src/get_wqp_inventory.R
@@ -69,7 +69,8 @@ inventory_wqp <- function(grid, char_names, wqp_args = NULL, max_tries = 3){
       select(MonitoringLocationIdentifier, HorizontalCoordinateReferenceSystemDatumName) %>%
       filter(MonitoringLocationIdentifier %in% wqp_inventory$MonitoringLocationIdentifier),
     error = function(e){
-      data.frame(MonitoringLocationIdentifier = character(), HorizontalCoordinateReferenceSystemDatumName = character())
+      data.frame(MonitoringLocationIdentifier = character(), 
+                 HorizontalCoordinateReferenceSystemDatumName = character())
     }
   )
 

--- a/1_inventory/src/get_wqp_inventory.R
+++ b/1_inventory/src/get_wqp_inventory.R
@@ -60,12 +60,19 @@ inventory_wqp <- function(grid, char_names, wqp_args = NULL, max_tries = 3){
   }) %>%
     bind_rows()
   
-  # Fetch missing CRS information from WQP
-  site_location_metadata <- dataRetrieval::whatWQPsites(
-    bBox = c(bbox$xmin, bbox$ymin, bbox$xmax, bbox$ymax)) %>%
-    select(MonitoringLocationIdentifier, HorizontalCoordinateReferenceSystemDatumName) %>%
-    filter(MonitoringLocationIdentifier %in% wqp_inventory$MonitoringLocationIdentifier)
-  
+  # Fetch missing CRS information from WQP. Note that an empty query will not
+  # contain CRS information. In the event that the lines below throw an error, 
+  # "Column `HorizontalCoordinateReferenceSystemDatumName` doesn't exist", return
+  # an empty data frame for the site location metadata. 
+  site_location_metadata <- tryCatch(
+    dataRetrieval::whatWQPsites(bBox = c(bbox$xmin, bbox$ymin, bbox$xmax, bbox$ymax)) %>%
+      select(MonitoringLocationIdentifier, HorizontalCoordinateReferenceSystemDatumName) %>%
+      filter(MonitoringLocationIdentifier %in% wqp_inventory$MonitoringLocationIdentifier),
+    error = function(e){
+      data.frame(MonitoringLocationIdentifier = character())
+    }
+  )
+
   # Join WQP inventory with site metadata 
   wqp_inventory_out <- wqp_inventory %>%
     left_join(site_location_metadata, by = "MonitoringLocationIdentifier")


### PR DESCRIPTION
An empty query will not contain the column `HorizontalCoordinateReferenceSystemDatumName` and so this PR adds a `tryCatch` wrapper around the lines in `inventory_wqp()` that fetch the site metadata. If a query is _not_ empty, we use the site metadata to harmonize the site coordinate reference systems. But if the query is empty, this step is moot and we just want `inventory_wqp()` to quietly return an empty data frame without complaining about the missing datum column. 

Closes #96 