### PR TITLE
Add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+## CHANGELOG
+
+<b>2022-12-19</b>  
+ * Add timeout settings and retry handling to data download step to make large data pulls more fault-tolerant
+
+<b>2022-11-02</b>  
+ * Minor changes to make inventory step robust to empty queries (e.g. if the user-specified area of interest includes grid cells that do not contain WQP data)
+ 
+<b>2022-09-01</b>  
+ * Initial release of WQP template pipeline


### PR DESCRIPTION
This PR adds a project changelog to inform users of any edits to the template WQP pipeline after the initial release in September 2022. I don't intend to release formal versions of the code for now, so the changelog is organized in reverse chronological order by date. 

Closes #100 