### PR TITLE
Save "siteInfo" attributes in a new target

### DIFF
--- a/2_download.R
+++ b/2_download.R
@@ -1,7 +1,7 @@
 # Source the functions that will be used to build the targets in p2_targets_list
 source("2_download/src/fetch_wqp_helpers.R")
 source("2_download/src/fetch_wqp_data.R")
-source("2_download/src/fetch_wqp_sites.R")
+source("2_download/src/fetch_wqp_site_info.R")
 source("2_download/src/summarize_wqp_download.R")
 
 p2_targets_list <- list(
@@ -48,15 +48,13 @@ p2_targets_list <- list(
     error = "continue"
   ),
   
-  # Fetch site metadata information that was downloaded along with the WQP data;
-  # resulting data frame contains one row for each record in `p2_wqp_data_aoi`
+  # Fetch site metadata that was downloaded along with the WQP data in 
+  # `p2_wqp_data_aoi`. Then reduce site info to return one row per unique site.
   tar_target(
     p2_wqp_site_info_all_records,
-    fetch_wqp_sites(p2_wqp_data_aoi),
+    fetch_wqp_site_info(p2_wqp_data_aoi),
     pattern = map(p2_wqp_data_aoi)
   ),
-  
-  # Reduce site metadata to return one row per site
   tar_target(
     p2_wqp_site_info,
     distinct(p2_wqp_site_info_all_records)

--- a/2_download.R
+++ b/2_download.R
@@ -1,4 +1,5 @@
 # Source the functions that will be used to build the targets in p2_targets_list
+source("2_download/src/retry.R")
 source("2_download/src/fetch_wqp_helpers.R")
 source("2_download/src/fetch_wqp_data.R")
 source("2_download/src/fetch_wqp_site_info.R")
@@ -48,12 +49,12 @@ p2_targets_list <- list(
     error = "continue"
   ),
   
-  # Fetch site metadata that was downloaded along with the WQP data in 
-  # `p2_wqp_data_aoi`. Then reduce site info to return one row per unique site.
+  # Fetch site metadata for all sites in each download group. Then reduce site
+  # info to return one row for each unique site.
   tar_target(
     p2_wqp_site_info_all_records,
-    fetch_wqp_site_info(p2_wqp_data_aoi),
-    pattern = map(p2_wqp_data_aoi)
+    fetch_wqp_site_info(site_ids = unique(p2_site_counts_grouped$site_id)),
+    pattern = map(p2_site_counts_grouped)
   ),
   tar_target(
     p2_wqp_site_info,

--- a/2_download.R
+++ b/2_download.R
@@ -1,6 +1,7 @@
 # Source the functions that will be used to build the targets in p2_targets_list
 source("2_download/src/fetch_wqp_helpers.R")
 source("2_download/src/fetch_wqp_data.R")
+source("2_download/src/fetch_wqp_sites.R")
 source("2_download/src/summarize_wqp_download.R")
 
 p2_targets_list <- list(
@@ -45,6 +46,20 @@ p2_targets_list <- list(
                    wqp_args = wqp_args),
     pattern = map(p2_site_counts_grouped),
     error = "continue"
+  ),
+  
+  # Fetch site metadata information that was downloaded along with the WQP data;
+  # resulting data frame contains one row for each record in `p2_wqp_data_aoi`
+  tar_target(
+    p2_wqp_site_info_all_records,
+    fetch_wqp_sites(p2_wqp_data_aoi),
+    pattern = map(p2_wqp_data_aoi)
+  ),
+  
+  # Reduce site metadata to return one row per site
+  tar_target(
+    p2_wqp_site_info,
+    distinct(p2_wqp_site_info_all_records)
   ),
   
   # Summarize the data downloaded from the WQP

--- a/2_download/src/fetch_wqp_data.R
+++ b/2_download/src/fetch_wqp_data.R
@@ -18,6 +18,9 @@
 #' @param wqp_args list containing additional arguments to pass to whatWQPdata(),
 #' defaults to NULL. See https://www.waterqualitydata.us/webservices_documentation 
 #' for more information.
+#' @param ignore_attributes logical; should site and parameter attributes be 
+#' appended to the data (FALSE) or left out/ignored (TRUE)? Default is TRUE since
+#' site location metadata is retrieved separately within the pipeline. 
 #' @param max_tries integer indicating the maximum number of retry attempts.
 #' @param timeout_minutes_per_site integer; indicates the maximum time that should be
 #' allowed to elapse per site before retrying the data download step. The total time
@@ -39,6 +42,7 @@
 fetch_wqp_data <- function(site_counts_grouped, 
                            char_names, 
                            wqp_args = NULL, 
+                           ignore_attributes = TRUE,
                            max_tries = 3, 
                            timeout_minutes_per_site = 5, 
                            sleep_on_error = 0, 
@@ -56,11 +60,13 @@ fetch_wqp_data <- function(site_counts_grouped,
   if(all(site_counts_grouped$pull_by_id)){
     wqp_args_all <- c(wqp_args, 
                       list(siteid = site_counts_grouped$site_id,
-                           characteristicName = c(char_names)))
+                           characteristicName = c(char_names),
+                           ignore_attributes = ignore_attributes))
   } else {
     wqp_args_all <- c(wqp_args, 
                       list(bBox = create_site_bbox(site_counts_grouped),
-                           characteristicName = c(char_names)))
+                           characteristicName = c(char_names),
+                           ignore_attributes = ignore_attributes))
   }
 
   # Pull the data, retrying up to the number of times indicated by `max_tries`.

--- a/2_download/src/fetch_wqp_data.R
+++ b/2_download/src/fetch_wqp_data.R
@@ -1,5 +1,3 @@
-source("2_download/src/retry.R")
-
 #' @title Download data from the Water Quality Portal
 #' 
 #' @description 

--- a/2_download/src/fetch_wqp_site_info.R
+++ b/2_download/src/fetch_wqp_site_info.R
@@ -6,7 +6,7 @@
 #' @details 
 #' This function will make multiple attempts to call the WQP "Station" service
 #' if the initial request fails or if the query takes too long to return results.
-#' See `2_download/src/retry.R` for more information about retry handling. See
+#' See `2_download/src/retry.R` for more information about retry handling.
 #' 
 #' @param site_ids character string or character vector indicating the site
 #' identifiers to request from the WQP "Station" service.

--- a/2_download/src/fetch_wqp_site_info.R
+++ b/2_download/src/fetch_wqp_site_info.R
@@ -1,30 +1,67 @@
 #' @title Fetch WQP site metadata
 #' 
 #' @description 
-#' Function to pull site location metadata from the WQP data attributes.
+#' Function to pull site location metadata for Water Quality Portal sites.
 #' 
 #' @details 
-#' Data downloaded from WQP using `dataRetrieval` contain an appended attribute 
-#' called "siteInfo" by default. These attributes are not retained when `targets`
-#' maps across the groups of sites to build `p2_wqp_data_aoi`. This function pulls
-#' out the site information for each branch within `p2_wqp_data_aoi` and then binds
-#' the rows into a single data frame.
+#' This function will make multiple attempts to call the WQP "Station" service
+#' if the initial request fails or if the query takes too long to return results.
+#' See `2_download/src/retry.R` for more information about retry handling. See
 #' 
-#' @param wqp_data data frame containing the data downloaded from the WQP, 
-#' where each row represents a unique data record.
+#' @param site_ids character string or character vector indicating the site
+#' identifiers to request from the WQP "Station" service.
+#' @param max_tries integer indicating the maximum number of retry attempts.
+#' @param timeout_minutes_per_site integer; indicates the maximum time that should be
+#' allowed to elapse per site before retrying the data download step. The total time
+#' used for the retry is calculated as number of sites * `timeout_minutes_per_site`.
+#' Defaults to 5 minutes per site. 
+#' @param sleep_on_error integer indicating how long (in seconds) we should wait 
+#' before making another attempt. Defaults to zero.
+#' @param verbose logical; should messages about retry status be printed to the
+#' console? Defaults to FALSE.  
 #' 
 #' @returns 
 #' Returns a data frame containing the site location metadata. Note that
 #' some records contain character strings when we expect numeric values.
 #' To bind the records together, all columns are formatted as character.
 #'
-fetch_wqp_site_info <- function(wqp_data){
+fetch_wqp_site_info <- function(site_ids, 
+                                max_tries = 3, 
+                                timeout_minutes_per_site = 5, 
+                                sleep_on_error = 0, 
+                                verbose = FALSE){
 
+  # Define how long to wait before the WQP query times out. For any single 
+  # attempt, stop and retry if the time elapsed exceeds `timeout_minutes`. Use 
+  # at least 1 minute so that it doesn't error if `length(site_ids) == 0`.
+  timeout_minutes <- 1 + timeout_minutes_per_site * length(site_ids)
+  
+  # Download site metadata from the "Station" service, using the fault-tolerant
+  # wrapper function `pull_data_safely` (see `2_download/src/retry.R`).
+  wqp_args <- list(siteid = site_ids, service = "Station")
+  site_info <- pull_data_safely(dataRetrieval::whatWQPsites, wqp_args,
+                                timeout_minutes = timeout_minutes,
+                                max_tries = max_tries, 
+                                sleep_on_error = sleep_on_error,
+                                verbose = verbose)
+  
+  # Add columns to match NWIS format and `dataRetrieval::readWQPdata` output:
+  # https://github.com/DOI-USGS/dataRetrieval/blob/main/R/readWQPdata.R#L233-L257
+  site_info_full <- site_info %>%
+    mutate(station_nm = MonitoringLocationName,
+           agency_cd = OrganizationIdentifier,
+           site_no = MonitoringLocationIdentifier,
+           dec_lat_va = LatitudeMeasure,
+           dec_lon_va = LongitudeMeasure,
+           hucCd = HUCEightDigitCode) %>%
+    select(station_nm, agency_cd, site_no, dec_lat_va, dec_lon_va, hucCd,
+           everything())
+  
   # Some records return character strings when we expect numeric values, e.g. if
   # `HorizontalAccuracyMeasure.MeasureValue == "Unknown"`. For now, format all 
   # columns as character so that individual data frames can be joined together 
   # in the targets pipeline. 
-  site_info_fmt <- attributes(wqp_data)$siteInfo %>%
+  site_info_fmt <- site_info_full %>%
     mutate(across(everything(), as.character))
   
   return(site_info_fmt)

--- a/2_download/src/fetch_wqp_site_info.R
+++ b/2_download/src/fetch_wqp_site_info.R
@@ -1,3 +1,29 @@
+#' @title Group unique site identifiers
+#' 
+#' @description 
+#' Function to split unique WQP site identifiers into smaller groups to 
+#' facilitate reasonably sized requests to the WQP "Station" service. 
+#' 
+#' @param site_ids character vector indicating the site identifiers that will
+#' be split into distinct groups based on the some number of max sites.
+#' @param max_sites integer indicating the maximum number of sites allowed in
+#' each group. Defaults to 500.
+#' 
+#' @returns 
+#' Returns a data frame with columns "site_id" and "site_group".
+#' 
+add_site_groups <- function(site_ids, max_sites){
+  
+  site_ids_grouped <- tibble(site_id = site_ids) %>%
+    distinct() %>%
+    group_by(site_group = ceiling(row_number()/max_sites)) %>%
+    ungroup()
+  
+  return(site_ids_grouped)
+}
+
+
+
 #' @title Fetch WQP site metadata
 #' 
 #' @description 

--- a/2_download/src/fetch_wqp_site_info.R
+++ b/2_download/src/fetch_wqp_site_info.R
@@ -16,8 +16,7 @@ add_site_groups <- function(site_ids, max_sites){
   
   site_ids_grouped <- tibble(site_id = site_ids) %>%
     distinct() %>%
-    group_by(site_group = ceiling(row_number()/max_sites)) %>%
-    ungroup()
+    mutate(site_group = ceiling(row_number()/max_sites))
   
   return(site_ids_grouped)
 }

--- a/2_download/src/fetch_wqp_site_info.R
+++ b/2_download/src/fetch_wqp_site_info.R
@@ -1,13 +1,13 @@
-#' @title Fetch WQP site info 
+#' @title Fetch WQP site metadata
 #' 
 #' @description 
-#' Function to fetch site location metadata from WQP data tables
+#' Function to pull site location metadata from the WQP data attributes.
 #' 
 #' @details 
-#' Data downloaded from WQP contain an appended attribute called "siteInfo" 
-#' by default. These attributes are not retained when targets maps across the
-#' groups of sites to build `p2_wqp_data_aoi` and so this function pulls out
-#' the site information for each branch within `p2_wqp_data_aoi` and then binds
+#' Data downloaded from WQP using `dataRetrieval` contain an appended attribute 
+#' called "siteInfo" by default. These attributes are not retained when `targets`
+#' maps across the groups of sites to build `p2_wqp_data_aoi`. This function pulls
+#' out the site information for each branch within `p2_wqp_data_aoi` and then binds
 #' the rows into a single data frame.
 #' 
 #' @param wqp_data data frame containing the data downloaded from the WQP, 
@@ -18,7 +18,7 @@
 #' some records contain character strings when we expect numeric values.
 #' To bind the records together, all columns are formatted as character.
 #'
-fetch_wqp_sites <- function(wqp_data){
+fetch_wqp_site_info <- function(wqp_data){
 
   # Some records return character strings when we expect numeric values, e.g. if
   # `HorizontalAccuracyMeasure.MeasureValue == "Unknown"`. For now, format all 

--- a/2_download/src/fetch_wqp_sites.R
+++ b/2_download/src/fetch_wqp_sites.R
@@ -1,0 +1,33 @@
+#' @title Fetch WQP site info 
+#' 
+#' @description 
+#' Function to fetch site location metadata from WQP data tables
+#' 
+#' @details 
+#' Data downloaded from WQP contain an appended attribute called "siteInfo" 
+#' by default. These attributes are not retained when targets maps across the
+#' groups of sites to build `p2_wqp_data_aoi` and so this function pulls out
+#' the site information for each branch within `p2_wqp_data_aoi` and then binds
+#' the rows into a single data frame.
+#' 
+#' @param wqp_data data frame containing the data downloaded from the WQP, 
+#' where each row represents a unique data record.
+#' 
+#' @returns 
+#' Returns a data frame containing the site location metadata. Note that
+#' some records contain character strings when we expect numeric values.
+#' To bind the records together, all columns are formatted as character.
+#'
+fetch_wqp_sites <- function(wqp_data){
+
+  # Some records return character strings when we expect numeric values, e.g. if
+  # `HorizontalAccuracyMeasure.MeasureValue == "Unknown"`. For now, format all 
+  # columns as character so that individual data frames can be joined together 
+  # in the targets pipeline. 
+  site_info_fmt <- attributes(wqp_data)$siteInfo %>%
+    mutate(across(everything(), as.character))
+  
+  return(site_info_fmt)
+}
+
+


### PR DESCRIPTION
This PR grabs the `siteInfo` attribute from each branch of `p2_wqp_data_aoi` to create a new target called `p2_wqp_site_info`. The site metadata attribute does not get retained when `p2_wqp_data_aoi` is built by binding the individual branches, and so the new site info target contains a table that users can reference or join with the data table if they wish.

As of the last time I built `p2_wqp_data_aoi`, we downloaded data from 552 sites within our example "watershed" and so `p2_wqp_site_info` contains site metadata for 552 sites: 
 ```r
tar_load(p2_wqp_data_aoi)
length(unique(p2_wqp_data_aoi$MonitoringLocationIdentifier))
[1] 552
tar_load(p2_wqp_site_info)
dim(p2_wqp_site_info)
[1] 552  43
names(p2_wqp_site_info)
 [1] "station_nm"                                      "agency_cd"                                       "site_no"                                        
 [4] "dec_lat_va"                                      "dec_lon_va"                                      "hucCd"                                          
 [7] "OrganizationIdentifier"                          "OrganizationFormalName"                          "MonitoringLocationIdentifier"                   
[10] "MonitoringLocationName"                          "MonitoringLocationTypeName"                      "MonitoringLocationDescriptionText"              
[13] "HUCEightDigitCode"                               "DrainageAreaMeasure.MeasureValue"                "DrainageAreaMeasure.MeasureUnitCode"            
[16] "ContributingDrainageAreaMeasure.MeasureValue"    "ContributingDrainageAreaMeasure.MeasureUnitCode" "LatitudeMeasure"                                
[19] "LongitudeMeasure"                                "SourceMapScaleNumeric"                           "HorizontalAccuracyMeasure.MeasureValue"         
[22] "HorizontalAccuracyMeasure.MeasureUnitCode"       "HorizontalCollectionMethodName"                  "HorizontalCoordinateReferenceSystemDatumName"   
[25] "VerticalMeasure.MeasureValue"                    "VerticalMeasure.MeasureUnitCode"                 "VerticalAccuracyMeasure.MeasureValue"           
[28] "VerticalAccuracyMeasure.MeasureUnitCode"         "VerticalCollectionMethodName"                    "VerticalCoordinateReferenceSystemDatumName"     
[31] "CountryCode"                                     "StateCode"                                       "CountyCode"                                     
[34] "AquiferName"                                     "LocalAqfrName"                                   "FormationTypeText"                              
[37] "AquiferTypeName"                                 "ConstructionDateText"                            "WellDepthMeasure.MeasureValue"                  
[40] "WellDepthMeasure.MeasureUnitCode"                "WellHoleDepthMeasure.MeasureValue"               "WellHoleDepthMeasure.MeasureUnitCode"           
[43] "ProviderName"                                   
>
```

@lindsayplatt, there's not a rush to merge this PR, I'm just trying to wrap up a couple lingering issues before some outreach that @padilla410 is planning for this spring. I'd suggest ~3 weeks turnaround, but let me know if you're swamped. This is the last set of code changes I'll make before releasing a new tag (see #103). 

Closes #95 