### PR TITLE
Print error message if inventory is empty

### DIFF
--- a/1_inventory/src/get_wqp_inventory.R
+++ b/1_inventory/src/get_wqp_inventory.R
@@ -198,7 +198,8 @@ subset_inventory <- function(wqp_inventory, aoi_sf, buffer_dist_m = 0){
   # First, check that the inventory is not empty
   if(nrow(wqp_inventory) == 0){
     stop(paste0("The WQP inventory is empty. No sites matching the requested ",
-                "input arguments were returned during the inventory step."))
+                "inputs were returned during the inventory step. Change the ",
+                "input arguments and try again."))
   }
   
   # Harmonize different coordinate reference systems used across sites

--- a/1_inventory/src/get_wqp_inventory.R
+++ b/1_inventory/src/get_wqp_inventory.R
@@ -195,6 +195,12 @@ transform_site_locations <- function(sites, crs_out = "WGS84"){
 #' 
 subset_inventory <- function(wqp_inventory, aoi_sf, buffer_dist_m = 0){
   
+  # First, check that the inventory is not empty
+  if(nrow(wqp_inventory) == 0){
+    stop(paste0("The WQP inventory is empty. No sites matching the requested ",
+                "input arguments were returned during the inventory step."))
+  }
+  
   # Harmonize different coordinate reference systems used across sites
   queried_sites_transformed <- transform_site_locations(wqp_inventory, crs_out= "WGS84") 
   queried_sites_transformed_sf <- sf::st_as_sf(queried_sites_transformed, 


### PR DESCRIPTION
This PR includes minor changes to `1_inventory/src/subset_inventory.R` to check whether the inventory is empty _before_ attempting to harmonize disparate datums or subset the inventoried sites to the user's AOI. If the inventory is empty, print a more informative error message for the user. Motivation for these changes as well as a reprex are included in #104.

Again, @lindsayplatt, there's not any rush to merge this PR, so feel free to take a quick look whenever you're able. Thanks!

Closes #104 

