### PR TITLE
Describe use of intermediate data files

### DIFF
--- a/2_download.R
+++ b/2_download.R
@@ -69,7 +69,7 @@ p2_targets_list <- list(
   tar_target(
     p2_wqp_data_summary_csv,
     summarize_wqp_download(p1_wqp_inventory_summary_csv, p2_wqp_data_aoi, 
-                       "2_download/log/summary_wqp_data.csv"),
+                           "2_download/log/summary_wqp_data.csv"),
     format = "file"
   )
 

--- a/2_download/src/fetch_wqp_helpers.R
+++ b/2_download/src/fetch_wqp_helpers.R
@@ -200,6 +200,7 @@ create_site_bbox <- function(sites, buffer_dist_degrees = 0.005){
 #'  
 #' @param fileout character string indicating the name of the output file, 
 #' including file path and .csv extension.
+#' @param ... additional arguments to pass to `fetch_wqp_data()`
 #' 
 #' @returns
 #' Saves a .csv file containing data downloaded from the Water Quality Portal, 
@@ -207,12 +208,8 @@ create_site_bbox <- function(sites, buffer_dist_degrees = 0.005){
 #' 
 fetch_and_save_wqp_data <- function(site_counts_grouped, 
                                     char_names,
-                                    wqp_args = NULL, 
-                                    max_tries = 3, 
-                                    timeout_minutes_per_site = 5, 
-                                    sleep_on_error = 0, 
-                                    verbose = FALSE,
-                                    fileout){
+                                    fileout, 
+                                    ...){
   
   # First check that fileout matches the expected format
   if(!grepl(".csv", fileout)){
@@ -220,13 +217,7 @@ fetch_and_save_wqp_data <- function(site_counts_grouped,
   }
   
   # Download the data
-  wqp_data <- fetch_wqp_data(site_counts_grouped, 
-                             char_names,
-                             wqp_args, 
-                             max_tries,
-                             timeout_minutes_per_site,
-                             sleep_on_error,
-                             verbose)
+  wqp_data <- fetch_wqp_data(site_counts_grouped, char_names, ...)
   
   # Write data to .csv file
   readr::write_csv(wqp_data, fileout)

--- a/2_download/src/fetch_wqp_helpers.R
+++ b/2_download/src/fetch_wqp_helpers.R
@@ -183,3 +183,55 @@ create_site_bbox <- function(sites, buffer_dist_degrees = 0.005){
   return(site_bbox)
 }
 
+
+
+#' @title Download and save WQP data
+#' 
+#' @description 
+#' Function to pull WQP data given a dataset of site ids and/or site coordinates.
+#' The downloaded data will be saved as a .csv file.
+#' 
+#' @details
+#' NOTE: THIS FUNCTION IS NOT CURRENTLY USED IN THE DATA DOWNLOAD PIPELINE.
+#' This function is a wrapper around `fetch_wqp_data` and is included as an 
+#' optional helper function. This function may be further modified to accommodate
+#' different file types (.feather, .qs, .txt, .rds). See `fetch_wqp_data` for a 
+#' complete description of function arguments.
+#'  
+#' @param fileout character string indicating the name of the output file, 
+#' including file path and .csv extension.
+#' 
+#' @returns
+#' Saves a .csv file containing data downloaded from the Water Quality Portal, 
+#' where each row represents one data record.
+#' 
+fetch_and_save_wqp_data <- function(site_counts_grouped, 
+                                    char_names,
+                                    wqp_args = NULL, 
+                                    max_tries = 3, 
+                                    timeout_minutes_per_site = 5, 
+                                    sleep_on_error = 0, 
+                                    verbose = FALSE,
+                                    fileout){
+  
+  # First check that fileout matches the expected format
+  if(!grepl(".csv", fileout)){
+    stop("Check that fileout has .csv extension")
+  }
+  
+  # Download the data
+  wqp_data <- fetch_wqp_data(site_counts_grouped, 
+                             char_names,
+                             wqp_args, 
+                             max_tries,
+                             timeout_minutes_per_site,
+                             sleep_on_error,
+                             verbose)
+  
+  # Write data to .csv file
+  readr::write_csv(wqp_data, fileout)
+  return(fileout)
+}
+
+
+

--- a/README.md
+++ b/README.md
@@ -170,8 +170,7 @@ If the pipeline has been run previously, only the nitrate data will be impacted 
 ### Troubleshooting large-scale data pulls
 The pipeline code attempts to split large data requests into smaller groups for download (discussed further in the "Comments on pipeline design" section below). `targets` downloads the data for the individual download groups and then combines the results into a single data frame in `p2_wqp_data_aoi`. This approach may not work well in all cases, and large-scale data pulls may even result in memory allocation errors if the data frame size exceeds the memory space available to R. 
 
-An alternative pattern is to save intermediate files that contain the data downloaded for each download group in `p2_site_counts_grouped`. The target `p2_wqp_data_aoi` can be modified to use an optional helper function that saves the intermediate files instead of returning a data frame, as shown 
-below. Note that any downstream targets that are expecting a data frame would need to be updated to use the intermediate files instead. 
+An alternative pattern is to save intermediate files that contain the data downloaded for each download group in `p2_site_counts_grouped`. The target `p2_wqp_data_aoi` can be modified to use an optional helper function that saves the intermediate files instead of returning a data frame, as shown below. Note that any downstream targets that are expecting a data frame would need to be updated to use the intermediate files instead. 
 
 ```r
   tar_target(

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ source("3_harmonize/src/clean_nitrate_data.R")
 
 If the pipeline has been run previously, only the nitrate data will be impacted by this addition and the `targets` branches corresponding to the conductivity and temperature data subsets will be skipped over when building `p3_wqp_data_aoi_clean_param`.
 
-### Troubleshooting large-scale data pulls
+### Adapting this pipeline for large-scale data pulls
 The pipeline code attempts to split large data requests into smaller groups for download (discussed further in the "Comments on pipeline design" section below). `targets` downloads the data for the individual download groups and then combines the results into a single data frame in `p2_wqp_data_aoi`. This approach may not work well in all cases, and large-scale data pulls may even result in memory allocation errors if the data frame size exceeds the memory space available to R. 
 
 An alternative pattern is to save intermediate files that contain the data downloaded for each download group in `p2_site_counts_grouped`. The target `p2_wqp_data_aoi` can be modified to use an optional helper function that saves the intermediate files instead of returning a data frame, as shown below. Note that any downstream targets that are expecting a data frame would need to be updated to use the intermediate files instead. 


### PR DESCRIPTION
This PR adds an optional helper function `fetch_and_save_wqp_data()` to the repo and updates the README to describe how the downloaded data can alternatively be saved to intermediate data files. Intermediate data files are likely necessary for larger data pulls, especially on common laptop computers with limited memory for holding large data frames. 

Closes #99